### PR TITLE
Fix nil pointer

### DIFF
--- a/cmd/cluster-kube-scheduler-operator/render/render.go
+++ b/cmd/cluster-kube-scheduler-operator/render/render.go
@@ -147,7 +147,7 @@ func (r *renderOpts) Run() error {
 	}
 
 	// load and render templates
-	if renderConfig.Assets, err = assets.LoadFilesRecursively(r.assetInputDir, nil); err != nil {
+	if renderConfig.Assets, err = assets.LoadFilesRecursively(r.assetInputDir); err != nil {
 		return fmt.Errorf("failed loading assets from %q: %v", r.assetInputDir, err)
 	}
 	for _, manifestDir := range []string{"bootstrap-manifests", "manifests"} {


### PR DESCRIPTION
Without this we would get errors if predicates passed are nil

```
docker run -v $(pwd)/tls:/assets --rm openshift/origin-cluster-kube-scheduler-operator:latest /usr/bin/cluster-kube-scheduler-operator render --asset-input-dir=/assets --asset-output-dir=/assets/kube-scheduler-bootstrap --config-output-file=/assets/kube-scheduler-bootstrap/config --config-override-file=/usr/share/bootkube/manifests/config/config-overrides.yaml
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x6c68e8]

goroutine 1 [running]:
github.com/openshift/cluster-kube-scheduler-operator/vendor/github.com/openshift/library-go/pkg/assets.LoadFilesRecursively.func1(0xc4205bed70, 0x4c, 0x170be60, 0xc4202185b0, 0x0, 0x0, 0x17, 0xc420117500)
	/go/src/github.com/openshift/cluster-kube-scheduler-operator/vendor/github.com/openshift/library-go/pkg/assets/assets.go:125 +0xe8
path/filepath.walk(0xc4205bed70, 0x4c, 0x170be60, 0xc4202185b0, 0xc420356c00, 0x0, 0x0)
	/usr/local/go/src/path/filepath/path.go:357 +0x402
path/filepath.walk(0xc4205c28c0, 0x34, 0x170be60, 0xc4202184e0, 0xc420356c00, 0x0, 0x0)```