### PR TITLE
Unify kube-scheduler-config configmap names

### DIFF
--- a/bindata/bootkube/manifests/kube-system-kube-scheduler-config.yaml
+++ b/bindata/bootkube/manifests/kube-system-kube-scheduler-config.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: kube-scheduler-config
-  namespace: {{ .Namespace }}
+  namespace: kube-system
 data:
   config.yaml: |
     {{ .PostBootstrapKubeSchedulerConfig | indent 4 }}

--- a/bindata/v3.11.0/kube-scheduler/cm.yaml
+++ b/bindata/v3.11.0/kube-scheduler/cm.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   namespace: openshift-kube-scheduler
-  name: deployment-scheduler-config
+  name: deployment-kube-scheduler-config
 data:
   config.yaml:

--- a/bindata/v3.11.0/kube-scheduler/deployment.yaml
+++ b/bindata/v3.11.0/kube-scheduler/deployment.yaml
@@ -55,4 +55,4 @@ spec:
       volumes:
       - name: config
         configMap:
-          name: deployment-scheduler-config
+          name: deployment-kube-scheduler-config

--- a/hack/update-generated-bindata.sh
+++ b/hack/update-generated-bindata.sh
@@ -3,7 +3,7 @@ set -e
 set -u
 set -o pipefail
 
-cd $( readlink -f "$( dirname "${0}" )/.." )
+cd "$(dirname "${0}")/.."
 
 # Setup temporary GOPATH so we can install go-bindata from vendor
 export GOPATH=$( mktemp -d )


### PR DESCRIPTION
The kube-scheduler-config configmap created by the render command will live in kube-system, next to the phase-2 daemonset.

The config of phase-3 is supposed to be created by the operator (called `cm.yaml` in the other control plane component operators).