### PR TITLE
bindata: add memory request to kube-scheduler pod

### DIFF
--- a/bindata/v3.11.0/kube-scheduler/pod.yaml
+++ b/bindata/v3.11.0/kube-scheduler/pod.yaml
@@ -16,6 +16,9 @@ spec:
     command: ["hyperkube", "kube-scheduler"]
     args:
     - --config=/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml
+    resources:
+      requests:
+        memory: 50Mi
     volumeMounts:
     - mountPath: /etc/kubernetes/static-pod-resources
       name: resource-dir

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -213,6 +213,9 @@ spec:
     command: ["hyperkube", "kube-scheduler"]
     args:
     - --config=/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml
+    resources:
+      requests:
+        memory: 50Mi
     volumeMounts:
     - mountPath: /etc/kubernetes/static-pod-resources
       name: resource-dir


### PR DESCRIPTION
One in a series of PRs to set memory requests for all control plane and high memory use components.

We are encountering master instability (https://github.com/openshift/installer/pull/408 https://github.com/openshift/installer/pull/785) as the number of components increase because many components run `BestEffort` giving the scheduler no information on pod resource usage.

On a steady state empty cluster, `kube-scheduler` uses 35MB.

{pod_name="openshift-kube-scheduler-dev-master-0"} | 34770944

Because it is a control plane component, I'm giving it a buffer and setting to `50Mi`

@aveshagarwal @derekwaynecarr



