### PR TITLE
manifests: add memory request to operator pod

### DIFF
--- a/manifests/0000_11_cluster-kube-scheduler-operator_06_deployment.yaml
+++ b/manifests/0000_11_cluster-kube-scheduler-operator_06_deployment.yaml
@@ -25,6 +25,9 @@ spec:
         args:
         - "--config=/var/run/configmaps/config/config.yaml"
         - "-v=4"
+        resources:
+          requests:
+            memory: 50Mi
         volumeMounts:
         - mountPath: /var/run/configmaps/config
           name: config


### PR DESCRIPTION
Follow on to the previous PR #42 setting memory limit for the operator pod.

{pod_name="openshift-cluster-kube-scheduler-operator-74879b869b-qwbts"}	29687808

Uses 30Mi in practice. Setting to `50Mi` for some buffer.