### PR TITLE
update clusteroperator name to kube-scheduler

### DIFF
--- a/manifests/0000_11_kube-scheduler-operator_07_clusteroperator.yaml
+++ b/manifests/0000_11_kube-scheduler-operator_07_clusteroperator.yaml
@@ -1,0 +1,5 @@
+apiVersion: config.openshift.io/v1
+kind: ClusterOperator
+metadata:
+  name: kube-scheduler
+spec: {}

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -121,7 +121,7 @@ func RunOperator(ctx *controllercmd.ControllerContext) error {
 	)
 
 	clusterOperatorStatus := status.NewClusterOperatorStatusController(
-		"openshift-kube-scheduler-operator",
+		"kube-scheduler",
 		[]configv1.ObjectReference{
 			{Group: "kubescheduler.operator.openshift.io", Resource: "kubescheduleroperatorconfigs", Name: "cluster"},
 			{Resource: "namespaces", Name: operatorclient.TargetNamespace},


### PR DESCRIPTION
rename cluster operator resource to not stutter by

- dropping the openshift prefix
- dropping the operator suffix

/cc @sjenning @ravisantoshgudimetla @deads2k 