### PR TITLE
Generate CRD validations with kubebuilder

### DIFF
--- a/manifests/0000_11_kube-scheduler-operator_01_config.crd.yaml
+++ b/manifests/0000_11_kube-scheduler-operator_01_config.crd.yaml
@@ -1,16 +1,262 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
   name: kubescheduleroperatorconfigs.kubescheduler.operator.openshift.io
 spec:
-  scope: Cluster
   group: kubescheduler.operator.openshift.io
-  version: v1alpha1
   names:
+    categories:
+    - coreoperators
     kind: KubeSchedulerOperatorConfig
     plural: kubescheduleroperatorconfigs
     singular: kubescheduleroperatorconfig
-    categories:
-    - coreoperators    
-  subresources:
-    status: {}
+  scope: Cluster
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            failedRevisionLimit:
+              description: failedRevisionLimit is the number of failed static pod
+                installer revisions to keep on disk and in the api -1 = unlimited,
+                0 or unset = 5 (default)
+              format: int32
+              type: integer
+            forceRedeploymentReason:
+              description: forceRedeploymentReason can be used to force the redeployment
+                of the kube-scheduler by providing a unique string. This provides
+                a mechanism to kick a previously failed deployment and provide a reason
+                why you think it will work this time instead of failing again on the
+                same config.
+              type: string
+            logLevel:
+              description: logLevel is an intent based logging for an overall component.  It
+                does not give fine grained control, but it is a simple way to manage
+                coarse grained logging choices that operators have to interpret for
+                their operands.
+              type: string
+            managementState:
+              description: managementState indicates whether and how the operator
+                should manage the component
+              type: string
+            observedConfig:
+              description: observedConfig holds a sparse config that controller has
+                observed from the cluster state.  It exists in spec because it is
+                an input to the level for the operator
+              type: object
+            operandSpecs:
+              description: operandSpecs provide customization for functional units
+                within the component
+              items:
+                properties:
+                  name:
+                    description: name is the name of this unit.  The operator must
+                      be aware of it.
+                    type: string
+                  operandContainerSpecs:
+                    description: operandContainerSpecs are per-container options
+                    items:
+                      properties:
+                        name:
+                          description: name is the name of the container to modify
+                          type: string
+                        resources:
+                          description: resources are the requests and limits to place
+                            in the container.  Nil means to accept the defaults.
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  unsupportedResourcePatches:
+                    description: 'unsupportedResourcePatches are applied to the workload
+                      resource for this unit. This is an unsupported workaround if
+                      anything needs to be modified on the workload that is not otherwise
+                      configurable. TODO Decide: alternatively, we could simply include
+                      a RawExtension which is used in place of the "normal" default
+                      manifest'
+                    items:
+                      properties:
+                        patch:
+                          description: patch the patch itself
+                          type: string
+                        type:
+                          description: 'type is the type of patch to apply: jsonmerge,
+                            strategicmerge'
+                          type: string
+                      required:
+                      - type
+                      - patch
+                      type: object
+                    type: array
+                required:
+                - name
+                - operandContainerSpecs
+                - unsupportedResourcePatches
+                type: object
+              type: array
+            succeededRevisionLimit:
+              description: succeededRevisionLimit is the number of successful static
+                pod installer revisions to keep on disk and in the api -1 = unlimited,
+                0 or unset = 5 (default)
+              format: int32
+              type: integer
+            unsupportedConfigOverrides:
+              description: 'unsupportedConfigOverrides holds a sparse config that
+                will override any previously set options.  It only needs to be the
+                fields to override it will end up overlaying in the following order:
+                1. hardcoded defaults 2. observedConfig 3. unsupportedConfigOverrides'
+              type: object
+          required:
+          - managementState
+          - logLevel
+          - operandSpecs
+          - unsupportedConfigOverrides
+          - observedConfig
+          - forceRedeploymentReason
+          type: object
+        status:
+          properties:
+            conditions:
+              description: conditions is a list of conditions and their status
+              items:
+                properties:
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  message:
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                required:
+                - type
+                - status
+                type: object
+              type: array
+            generations:
+              description: generations are used to determine when an item needs to
+                be reconciled or has changed in a way that needs a reaction.
+              items:
+                properties:
+                  group:
+                    description: group is the group of the thing you're tracking
+                    type: string
+                  hash:
+                    description: hash is an optional field set for resources without
+                      generation that are content sensitive like secrets and configmaps
+                    type: string
+                  lastGeneration:
+                    description: lastGeneration is the last generation of the workload
+                      controller involved
+                    format: int64
+                    type: integer
+                  name:
+                    description: name is the name of the thing you're tracking
+                    type: string
+                  namespace:
+                    description: namespace is where the thing you're tracking is
+                    type: string
+                  resource:
+                    description: resource is the resource type of the thing you're
+                      tracking
+                    type: string
+                required:
+                - group
+                - resource
+                - namespace
+                - name
+                - lastGeneration
+                - hash
+                type: object
+              type: array
+            latestAvailableRevision:
+              description: latestAvailableRevision is the deploymentID of the most
+                recent deployment
+              format: int32
+              type: integer
+            nodeStatuses:
+              description: nodeStatuses track the deployment values and errors across
+                individual nodes
+              items:
+                properties:
+                  currentRevision:
+                    description: currentRevision is the generation of the most recently
+                      successful deployment
+                    format: int32
+                    type: integer
+                  lastFailedRevision:
+                    description: lastFailedRevision is the generation of the deployment
+                      we tried and failed to deploy.
+                    format: int32
+                    type: integer
+                  lastFailedRevisionErrors:
+                    description: lastFailedRevisionErrors is a list of the errors
+                      during the failed deployment referenced in lastFailedRevision
+                    items:
+                      type: string
+                    type: array
+                  nodeName:
+                    description: nodeName is the name of the node
+                    type: string
+                  targetRevision:
+                    description: targetRevision is the generation of the deployment
+                      we're trying to apply
+                    format: int32
+                    type: integer
+                required:
+                - nodeName
+                - currentRevision
+                - targetRevision
+                - lastFailedRevision
+                - lastFailedRevisionErrors
+                type: object
+              type: array
+            observedGeneration:
+              description: observedGeneration is the last generation change you've
+                dealt with
+              format: int64
+              type: integer
+            readyReplicas:
+              description: readyReplicas indicates how many replicas are ready and
+                at the desired state
+              format: int32
+              type: integer
+            version:
+              description: version is the level this availability applies to
+              type: string
+          required:
+          - version
+          - readyReplicas
+          - generations
+          - latestAvailableRevision
+          - nodeStatuses
+          type: object
+      required:
+      - metadata
+      - spec
+      - status
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/pkg/apis/kubescheduler/v1alpha1/types.go
+++ b/pkg/apis/kubescheduler/v1alpha1/types.go
@@ -17,6 +17,8 @@ type KubeSchedulerConfig struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // KubeSchedulerOperatorConfig provides information to configure an operator to manage kube-scheduler.
+// +kubebuilder:categories=coreoperators
+// +kubebuilder:singular=kubescheduleroperatorconfig
 type KubeSchedulerOperatorConfig struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`


### PR DESCRIPTION
Running `update-crds` will `go get` kubebuilder crd tool, generate the new CRD with validations based on Go types, and replace the current CRD file with the new one after some bash hack to get rid of buggy output from kubebuilder.

This depends on https://github.com/kubernetes-sigs/controller-tools/pull/142 for the new `singular` tag