### PR TITLE
Don't pass nil function pointer to NewConfigObserver

### DIFF
--- a/pkg/operator/configobservation/configobservercontroller/observe_config_controller.go
+++ b/pkg/operator/configobservation/configobservercontroller/observe_config_controller.go
@@ -34,7 +34,6 @@ func NewConfigObserver(
 					kubeInformersForOpenShiftKubeSchedulerNamespace.Core().V1().ConfigMaps().Informer().HasSynced,
 				},
 			},
-			nil,
 		),
 	}
 


### PR DESCRIPTION
While looking into a network deployment failure that might have been caused by a openshift-kube-scheduler-operator failure, I found this in the scheduler operator logs:

```
E0219 09:26:48.743792       1 runtime.go:69] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
/go/src/github.com/openshift/cluster-kube-scheduler-operator/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:76
/go/src/github.com/openshift/cluster-kube-scheduler-operator/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:65
/go/src/github.com/openshift/cluster-kube-scheduler-operator/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:51
/usr/local/go/src/runtime/asm_amd64.s:573
/usr/local/go/src/runtime/panic.go:502
/usr/local/go/src/runtime/panic.go:63
/usr/local/go/src/runtime/signal_unix.go:388
/go/src/github.com/openshift/cluster-kube-scheduler-operator/vendor/github.com/openshift/library-go/pkg/operator/configobserver/config_observer_controller.go:97
/go/src/github.com/openshift/cluster-kube-scheduler-operator/vendor/github.com/openshift/library-go/pkg/operator/configobserver/config_observer_controller.go:179
/go/src/github.com/openshift/cluster-kube-scheduler-operator/vendor/github.com/openshift/library-go/pkg/operator/configobserver/config_observer_controller.go:165
/go/src/github.com/openshift/cluster-kube-scheduler-operator/vendor/github.com/openshift/library-go/pkg/operator/configobserver/config_observer_controller.go:159
/go/src/github.com/openshift/cluster-kube-scheduler-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133
/go/src/github.com/openshift/cluster-kube-scheduler-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:134
/go/src/github.com/openshift/cluster-kube-scheduler-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:88
/usr/local/go/src/runtime/asm_amd64.s:2361
```

Turns out though, this happens repeatedly even in successful e2e-aws runs. (eg, https://storage.googleapis.com/origin-ci-test/pr-logs/pull/21987/pull-ci-openshift-origin-master-e2e-aws/4471/artifacts/e2e-aws/pods/openshift-kube-scheduler-operator_openshift-kube-scheduler-operator-6d58d94c74-lr22v_kube-scheduler-operator-container.log.gz)

I think this should fix it, though who knows what will start happening now that it's not panicking...