### PR TITLE
Change kubescheduler type name from instance to cluster

### DIFF
--- a/bindata/v3.11.0/kube-scheduler/operator-config.yaml
+++ b/bindata/v3.11.0/kube-scheduler/operator-config.yaml
@@ -1,7 +1,7 @@
 apiVersion: operator.openshift.io/v1
 kind: KubeScheduler
 metadata:
-  name: instance
+  name: cluster
 spec:
   managementState: Managed
   imagePullSpec: openshift/origin-hyperkube:latest

--- a/pkg/operator/operatorclient/operatorclient.go
+++ b/pkg/operator/operatorclient/operatorclient.go
@@ -19,7 +19,7 @@ func (c *OperatorClient) Informer() cache.SharedIndexInformer {
 }
 
 func (c *OperatorClient) GetStaticPodOperatorState() (*operatorv1.StaticPodOperatorSpec, *operatorv1.StaticPodOperatorStatus, string, error) {
-	instance, err := c.Informers.Operator().V1().KubeSchedulers().Lister().Get("instance")
+	instance, err := c.Informers.Operator().V1().KubeSchedulers().Lister().Get("cluster")
 	if err != nil {
 		return nil, nil, "", err
 	}
@@ -28,7 +28,7 @@ func (c *OperatorClient) GetStaticPodOperatorState() (*operatorv1.StaticPodOpera
 }
 
 func (c *OperatorClient) GetStaticPodOperatorStateWithQuorum() (*operatorv1.StaticPodOperatorSpec, *operatorv1.StaticPodOperatorStatus, string, error) {
-	instance, err := c.Client.KubeSchedulers().Get("instance", metav1.GetOptions{})
+	instance, err := c.Client.KubeSchedulers().Get("cluster", metav1.GetOptions{})
 	if err != nil {
 		return nil, nil, "", err
 	}
@@ -37,7 +37,7 @@ func (c *OperatorClient) GetStaticPodOperatorStateWithQuorum() (*operatorv1.Stat
 }
 
 func (c *OperatorClient) UpdateStaticPodOperatorStatus(resourceVersion string, status *operatorv1.StaticPodOperatorStatus) (*operatorv1.StaticPodOperatorStatus, error) {
-	original, err := c.Informers.Operator().V1().KubeSchedulers().Lister().Get("instance")
+	original, err := c.Informers.Operator().V1().KubeSchedulers().Lister().Get("cluster")
 	if err != nil {
 		return nil, err
 	}
@@ -54,7 +54,7 @@ func (c *OperatorClient) UpdateStaticPodOperatorStatus(resourceVersion string, s
 }
 
 func (c *OperatorClient) GetOperatorState() (*operatorv1.OperatorSpec, *operatorv1.OperatorStatus, string, error) {
-	instance, err := c.Informers.Operator().V1().KubeSchedulers().Lister().Get("instance")
+	instance, err := c.Informers.Operator().V1().KubeSchedulers().Lister().Get("cluster")
 	if err != nil {
 		return nil, nil, "", err
 	}
@@ -63,7 +63,7 @@ func (c *OperatorClient) GetOperatorState() (*operatorv1.OperatorSpec, *operator
 }
 
 func (c *OperatorClient) UpdateOperatorSpec(resourceVersion string, spec *operatorv1.OperatorSpec) (*operatorv1.OperatorSpec, string, error) {
-	original, err := c.Informers.Operator().V1().KubeSchedulers().Lister().Get("instance")
+	original, err := c.Informers.Operator().V1().KubeSchedulers().Lister().Get("cluster")
 	if err != nil {
 		return nil, "", err
 	}
@@ -79,7 +79,7 @@ func (c *OperatorClient) UpdateOperatorSpec(resourceVersion string, spec *operat
 	return &ret.Spec.OperatorSpec, ret.ResourceVersion, nil
 }
 func (c *OperatorClient) UpdateOperatorStatus(resourceVersion string, status *operatorv1.OperatorStatus) (*operatorv1.OperatorStatus, error) {
-	original, err := c.Informers.Operator().V1().KubeSchedulers().Lister().Get("instance")
+	original, err := c.Informers.Operator().V1().KubeSchedulers().Lister().Get("cluster")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -129,7 +129,7 @@ func RunOperator(ctx *controllercmd.ControllerContext) error {
 	clusterOperatorStatus := status.NewClusterOperatorStatusController(
 		"kube-scheduler",
 		[]configv1.ObjectReference{
-			{Group: "operator.openshift.io", Resource: "kubeschedulers", Name: "instance"},
+			{Group: "operator.openshift.io", Resource: "kubeschedulers", Name: "cluster"},
 			{Resource: "namespaces", Name: operatorclient.GlobalUserSpecifiedConfigNamespace},
 			{Resource: "namespaces", Name: operatorclient.TargetNamespace},
 			{Resource: "namespaces", Name: "openshift-kube-scheduler-operator"},

--- a/pkg/operator/target_config_reconciler.go
+++ b/pkg/operator/target_config_reconciler.go
@@ -76,7 +76,7 @@ func NewTargetConfigReconciler(
 }
 
 func (c TargetConfigReconciler) sync() error {
-	operatorConfig, err := c.operatorConfigClient.KubeSchedulers().Get("instance", metav1.GetOptions{})
+	operatorConfig, err := c.operatorConfigClient.KubeSchedulers().Get("cluster", metav1.GetOptions{})
 	if err != nil {
 		return err
 	}

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -244,7 +244,7 @@ func v3110KubeSchedulerNsYaml() (*asset, error) {
 var _v3110KubeSchedulerOperatorConfigYaml = []byte(`apiVersion: operator.openshift.io/v1
 kind: KubeScheduler
 metadata:
-  name: instance
+  name: cluster
 spec:
   managementState: Managed
   imagePullSpec: openshift/origin-hyperkube:latest


### PR DESCRIPTION
Switching the kubescheduler type name from `instance` to `cluster`.

/cc @deads2k 