### PR TITLE
Get feature gates and using them while starting kube-scheduler

### DIFF
--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -87,7 +87,6 @@ func RunOperator(ctx *controllercmd.ControllerContext) error {
 	if err != nil {
 		return err
 	}
-
 	configObserver := configobservercontroller.NewConfigObserver(
 		operatorClient,
 		operatorConfigInformers,

--- a/pkg/operator/target_config_reconciler_v311_00_test.go
+++ b/pkg/operator/target_config_reconciler_v311_00_test.go
@@ -1,0 +1,54 @@
+package operator
+
+import (
+	configv1 "github.com/openshift/api/config/v1"
+	configlistersv1 "github.com/openshift/client-go/config/listers/config/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+	"reflect"
+	"testing"
+)
+
+func TestCheckForFeatureGates(t *testing.T) {
+	tests := []struct {
+		name           string
+		configValue    configv1.FeatureSet
+		expectedResult map[string]bool
+	}{
+		{
+			name:        "default",
+			configValue: configv1.Default,
+			expectedResult: map[string]bool{
+				"ExperimentalCriticalPodAnnotation": true,
+				"RotateKubeletServerCertificate":    true,
+				"SupportPodPidsLimit":               true,
+				"LocalStorageCapacityIsolation":     false,
+			},
+		},
+		{
+			name:        "techpreview",
+			configValue: configv1.TechPreviewNoUpgrade,
+			expectedResult: map[string]bool{
+				"ExperimentalCriticalPodAnnotation": true,
+				"RotateKubeletServerCertificate":    true,
+				"SupportPodPidsLimit":               true,
+				"CSIBlockVolume":                    true,
+				"LocalStorageCapacityIsolation":     false,
+			},
+		},
+	}
+	for _, tc := range tests {
+		indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+		indexer.Add(&configv1.FeatureGate{
+			ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+			Spec: configv1.FeatureGateSpec{
+				FeatureSet: tc.configValue,
+			},
+		})
+		featureGateLister := configlistersv1.NewFeatureGateLister(indexer)
+		actualFeatureGates, _ := checkForFeatureGates(featureGateLister)
+		if !reflect.DeepEqual(actualFeatureGates, tc.expectedResult) {
+			t.Fatalf("Expected %v feature gates to be present but found %v", tc.expectedResult, actualFeatureGates)
+		}
+	}
+}

--- a/pkg/operator/target_config_reconciler_v311_00_test.go
+++ b/pkg/operator/target_config_reconciler_v311_00_test.go
@@ -46,7 +46,7 @@ func TestCheckForFeatureGates(t *testing.T) {
 			},
 		})
 		featureGateLister := configlistersv1.NewFeatureGateLister(indexer)
-		actualFeatureGates, _ := checkForFeatureGates(featureGateLister)
+		actualFeatureGates := checkForFeatureGates(featureGateLister)
 		if !reflect.DeepEqual(actualFeatureGates, tc.expectedResult) {
 			t.Fatalf("Expected %v feature gates to be present but found %v", tc.expectedResult, actualFeatureGates)
 		}


### PR DESCRIPTION
I was initially thinking of using config observer pattern to list feature gates and update kube-scheduler but later realized that we are updating any config related to kube-scheduler here but just updating one of the flags, so I have updated the target_config_reconciler.go. I haven't tested this locally.