### PR TITLE
Create a scheduler CR

### DIFF
--- a/pkg/operator/target_config_reconciler_v311_00.go
+++ b/pkg/operator/target_config_reconciler_v311_00.go
@@ -120,7 +120,7 @@ func manageKubeSchedulerConfigMap_v311_00_to_latest(lister corev1listers.ConfigM
 			defaultConfig = v311_00_assets.MustAsset("v3.11.0/kube-scheduler/defaultconfig-postbootstrap.yaml")
 		}
 	} else {
-		glog.Infof("Error while getting scheduler type %v and using default algorithm provider in kubernetes scheduler", err.Error())
+		glog.Info("Error while getting scheduler type and using default algorithm provider in kubernetes scheduler")
 		defaultConfig = v311_00_assets.MustAsset("v3.11.0/kube-scheduler/defaultconfig-postbootstrap.yaml")
 	}
 	requiredConfigMap, _, err := resourcemerge.MergeConfigMap(configMap, "config.yaml", nil, defaultConfig, operatorConfig.Spec.ObservedConfig.Raw, operatorConfig.Spec.UnsupportedConfigOverrides.Raw)


### PR DESCRIPTION
Creating a scheduler CR within kube-scheduler operator.

/cc @sjenning 

The downside to this
- KSO would not proceed to other controllers(target_config, resource_sync etc) without creating this CR.
- If the scheduler CRD doesn't exist, KSO won't proceed further as well.