### PR TITLE
Disable insecure port

### DIFF
--- a/bindata/bootkube/bootstrap-manifests/kube-scheduler-pod.yaml
+++ b/bindata/bootkube/bootstrap-manifests/kube-scheduler-pod.yaml
@@ -15,7 +15,7 @@ spec:
     imagePullPolicy: {{ .ImagePullPolicy }}
     command: ["/bin/bash", "-c"]
     args:
-    - exec hyperkube kube-scheduler --kubeconfig=/etc/kubernetes/secrets/kubeconfig --leader-elect=true --cert-dir=/var/run/kubernetes
+    - exec hyperkube kube-scheduler --kubeconfig=/etc/kubernetes/secrets/kubeconfig --leader-elect=true --cert-dir=/var/run/kubernetes --port 0
     volumeMounts:
     - mountPath: /etc/kubernetes/secrets
       name: secrets

--- a/bindata/v3.11.0/kube-scheduler/pod.yaml
+++ b/bindata/v3.11.0/kube-scheduler/pod.yaml
@@ -17,6 +17,7 @@ spec:
     args:
     - --config=/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml
     - --cert-dir=/var/run/kubernetes
+    - --port=0
     resources:
       requests:
         memory: 50Mi

--- a/bindata/v3.11.0/kube-scheduler/svc.yaml
+++ b/bindata/v3.11.0/kube-scheduler/svc.yaml
@@ -13,4 +13,4 @@ spec:
   ports:
   - name: https
     port: 443
-    targetPort: 8443
+    targetPort: 10259

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -316,6 +316,7 @@ spec:
     args:
     - --config=/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml
     - --cert-dir=/var/run/kubernetes
+    - --port=0
     resources:
       requests:
         memory: 50Mi

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -473,7 +473,7 @@ spec:
   ports:
   - name: https
     port: 443
-    targetPort: 8443
+    targetPort: 10259
 `)
 
 func v3110KubeSchedulerSvcYamlBytes() ([]byte, error) {


### PR DESCRIPTION
This is blocked by https://github.com/openshift/cluster-monitoring-operator/blob/172beb3e0d2cbf1f79bf61ba9c3f5bea373b4125/assets/prometheus-k8s/service-monitor-kube-scheduler.yaml#L15 pointing to the secure port.