### PR TITLE
pod.yaml: wire serving-cert secret

### DIFF
--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -174,4 +174,5 @@ var deploymentConfigMaps = []revision.RevisionResource{
 // deploymentSecrets is a list of secrets that are directly copied for the current values.  A different actor/controller modifies these.
 var deploymentSecrets = []revision.RevisionResource{
 	{Name: "kube-scheduler-client-cert-key"},
+	{Name: "serving-cert", Optional: true},
 }


### PR DESCRIPTION
Counterpart of https://github.com/openshift/cluster-kube-controller-manager-operator/pull/221. This is needed for monitoring to be able to verify the serving cert. Without this PR, only the self-signed cert is used by kube-scheduler.