### PR TITLE
Switch to go 1.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.10 AS builder
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.11 AS builder
 WORKDIR /go/src/github.com/openshift/cluster-kube-scheduler-operator
 COPY . .
 RUN go build ./cmd/cluster-kube-scheduler-operator

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -1,4 +1,4 @@
-FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.10 AS builder
+FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.11 AS builder
 WORKDIR /go/src/github.com/openshift/cluster-kube-scheduler-operator
 COPY . .
 RUN go build ./cmd/cluster-kube-scheduler-operator


### PR DESCRIPTION
Some of the gofmts might fail. Will create separate PRs to address them.

https://github.com/openshift/cluster-kube-apiserver-operator/pull/414