### PR TITLE
Use the CVO for operator config

### DIFF
--- a/manifests/0000_11_kube-scheduler-operator_02_operator.cr.yaml
+++ b/manifests/0000_11_kube-scheduler-operator_02_operator.cr.yaml
@@ -2,6 +2,8 @@ apiVersion: operator.openshift.io/v1
 kind: KubeScheduler
 metadata:
   name: cluster
+  annotations:
+    release.openshift.io/create-only: "true"
 spec:
   managementState: Managed
   imagePullSpec: openshift/origin-hyperkube:latest

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -7,14 +7,12 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 
 	configv1 "github.com/openshift/api/config/v1"
 
-	operatorv1 "github.com/openshift/api/operator/v1"
 	configv1client "github.com/openshift/client-go/config/clientset/versioned"
 	configv1informers "github.com/openshift/client-go/config/informers/externalversions"
 	operatorversionedclient "github.com/openshift/client-go/operator/clientset/versioned"
@@ -22,7 +20,6 @@ import (
 	"github.com/openshift/cluster-kube-scheduler-operator/pkg/operator/configobservation/configobservercontroller"
 	"github.com/openshift/cluster-kube-scheduler-operator/pkg/operator/operatorclient"
 	"github.com/openshift/cluster-kube-scheduler-operator/pkg/operator/resourcesynccontroller"
-	"github.com/openshift/cluster-kube-scheduler-operator/pkg/operator/v311_00_assets"
 	"github.com/openshift/library-go/pkg/controller/controllercmd"
 	"github.com/openshift/library-go/pkg/operator/staticpod"
 	"github.com/openshift/library-go/pkg/operator/staticpod/controller/revision"
@@ -70,12 +67,6 @@ func RunOperator(ctx *controllercmd.ControllerContext) error {
 
 	kubeInformersClusterScoped := informers.NewSharedInformerFactory(kubeClient, 10*time.Minute)
 	kubeInformersNamespace := informers.NewSharedInformerFactoryWithOptions(kubeClient, 10*time.Minute, informers.WithNamespace(operatorclient.TargetNamespace))
-
-	v1helpers.EnsureOperatorConfigExists(
-		dynamicClient,
-		v311_00_assets.MustAsset("v3.11.0/kube-scheduler/operator-config.yaml"),
-		schema.GroupVersionResource{Group: operatorv1.GroupName, Version: "v1", Resource: "kubeschedulers"},
-	)
 
 	resourceSyncController, err := resourcesynccontroller.NewResourceSyncController(
 		operatorClient,

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -7,7 +7,6 @@
 // bindata/v3.11.0/kube-scheduler/kubeconfig-cm.yaml
 // bindata/v3.11.0/kube-scheduler/leader-election-rolebinding.yaml
 // bindata/v3.11.0/kube-scheduler/ns.yaml
-// bindata/v3.11.0/kube-scheduler/operator-config.yaml
 // bindata/v3.11.0/kube-scheduler/pod-cm.yaml
 // bindata/v3.11.0/kube-scheduler/pod.yaml
 // bindata/v3.11.0/kube-scheduler/policyconfigmap-role.yaml
@@ -239,34 +238,6 @@ func v3110KubeSchedulerNsYaml() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "v3.11.0/kube-scheduler/ns.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
-	a := &asset{bytes: bytes, info: info}
-	return a, nil
-}
-
-var _v3110KubeSchedulerOperatorConfigYaml = []byte(`apiVersion: operator.openshift.io/v1
-kind: KubeScheduler
-metadata:
-  name: cluster
-spec:
-  managementState: Managed
-  imagePullSpec: openshift/origin-hyperkube:latest
-  version: 3.11.0
-  logging:
-    level: 4
-  replicas: 2
-`)
-
-func v3110KubeSchedulerOperatorConfigYamlBytes() ([]byte, error) {
-	return _v3110KubeSchedulerOperatorConfigYaml, nil
-}
-
-func v3110KubeSchedulerOperatorConfigYaml() (*asset, error) {
-	bytes, err := v3110KubeSchedulerOperatorConfigYamlBytes()
-	if err != nil {
-		return nil, err
-	}
-
-	info := bindataFileInfo{name: "v3.11.0/kube-scheduler/operator-config.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -581,7 +552,6 @@ var _bindata = map[string]func() (*asset, error){
 	"v3.11.0/kube-scheduler/kubeconfig-cm.yaml":                           v3110KubeSchedulerKubeconfigCmYaml,
 	"v3.11.0/kube-scheduler/leader-election-rolebinding.yaml":             v3110KubeSchedulerLeaderElectionRolebindingYaml,
 	"v3.11.0/kube-scheduler/ns.yaml":                                      v3110KubeSchedulerNsYaml,
-	"v3.11.0/kube-scheduler/operator-config.yaml":                         v3110KubeSchedulerOperatorConfigYaml,
 	"v3.11.0/kube-scheduler/pod-cm.yaml":                                  v3110KubeSchedulerPodCmYaml,
 	"v3.11.0/kube-scheduler/pod.yaml":                                     v3110KubeSchedulerPodYaml,
 	"v3.11.0/kube-scheduler/policyconfigmap-role.yaml":                    v3110KubeSchedulerPolicyconfigmapRoleYaml,
@@ -641,7 +611,6 @@ var _bintree = &bintree{nil, map[string]*bintree{
 			"kubeconfig-cm.yaml":                           {v3110KubeSchedulerKubeconfigCmYaml, map[string]*bintree{}},
 			"leader-election-rolebinding.yaml":             {v3110KubeSchedulerLeaderElectionRolebindingYaml, map[string]*bintree{}},
 			"ns.yaml":                                      {v3110KubeSchedulerNsYaml, map[string]*bintree{}},
-			"operator-config.yaml":                         {v3110KubeSchedulerOperatorConfigYaml, map[string]*bintree{}},
 			"pod-cm.yaml":                                  {v3110KubeSchedulerPodCmYaml, map[string]*bintree{}},
 			"pod.yaml":                                     {v3110KubeSchedulerPodYaml, map[string]*bintree{}},
 			"policyconfigmap-role.yaml":                    {v3110KubeSchedulerPolicyconfigmapRoleYaml, map[string]*bintree{}},


### PR DESCRIPTION
Switch away from using EnsureOperatorConfigExists, which is being removed in favor of CVO management of operator resources