### PR TITLE
Add node-selector annotation to namespace

### DIFF
--- a/bindata/bootkube/manifests/00_openshift-kube-scheduler-ns.yaml
+++ b/bindata/bootkube/manifests/00_openshift-kube-scheduler-ns.yaml
@@ -1,6 +1,8 @@
 apiVersion: v1
 kind: Namespace
 metadata:
+  annotations:
+    openshift.io/node-selector: ""
   name: openshift-kube-scheduler
   labels:
     openshift.io/run-level: "0"

--- a/bindata/v3.11.0/kube-scheduler/ns.yaml
+++ b/bindata/v3.11.0/kube-scheduler/ns.yaml
@@ -1,6 +1,8 @@
 apiVersion: v1
 kind: Namespace
 metadata:
+  annotations:
+    openshift.io/node-selector: ""
   name: openshift-kube-scheduler
   labels:
     openshift.io/run-level: "0"

--- a/manifests/0000_11_kube-scheduler-operator_00_namespace.yaml
+++ b/manifests/0000_11_kube-scheduler-operator_00_namespace.yaml
@@ -1,6 +1,8 @@
 apiVersion: v1
 kind: Namespace
 metadata:
+  annotations:
+    openshift.io/node-selector: ""
   labels:
     openshift.io/run-level: "0"
   name: openshift-kube-scheduler-operator

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -222,6 +222,8 @@ func v3110KubeSchedulerLeaderElectionRolebindingYaml() (*asset, error) {
 var _v3110KubeSchedulerNsYaml = []byte(`apiVersion: v1
 kind: Namespace
 metadata:
+  annotations:
+    openshift.io/node-selector: ""
   name: openshift-kube-scheduler
   labels:
     openshift.io/run-level: "0"


### PR DESCRIPTION
**Why this change?**
When https://github.com/openshift/cluster-kube-apiserver-operator/pull/394 merges, all the pods running openshift cluster will have a [defaultNodeSelector](https://docs.openshift.com/container-platform/3.11/admin_guide/managing_projects.html#setting-the-cluster-wide-default-node-selector) if it has been set by cluster-admin including pods running in `openshift-*` namespace. The main advantage of having that feature is in a multi-tenant environment, any new project created can be steered towards compute nodes(non-master nodes).

**What should I do?**
If you think, the pods in your namespace shouldn't have defaultNodeSelector set, please review this PR. If not feel free to close this. The annotation added as part of this PR lets all the pods created within your project to not have the defaultNodeSelector set.


/cc @deads2k @sjenning 
