### PR TITLE
change initial loglevel to align with logging controller defaults

### DIFF
--- a/manifests/0000_25_kube-scheduler-operator_06_deployment.yaml
+++ b/manifests/0000_25_kube-scheduler-operator_06_deployment.yaml
@@ -24,7 +24,7 @@ spec:
         command: ["cluster-kube-scheduler-operator", "operator"]
         args:
         - "--config=/var/run/configmaps/config/config.yaml"
-        - "-v=4"
+        - "-v=2"
         resources:
           requests:
             memory: 50Mi


### PR DESCRIPTION
@deads2k @mfojtik @ravisantoshgudimetla 

avoids the `Operator log level changed from "Debug" to "Normal"` event on KSO restart, since the logging controller defaults an empty loglevel to be `Normal` or `2`.

also see
https://github.com/openshift/library-go/pull/375