### PR TITLE
static-pod: fail liveness when secrets/kube-scheduler-client-cert-key changes

### DIFF
--- a/bindata/v3.11.0/kube-scheduler/pod.yaml
+++ b/bindata/v3.11.0/kube-scheduler/pod.yaml
@@ -42,12 +42,16 @@ spec:
     - mountPath: /etc/kubernetes/static-pod-resources
       name: resource-dir
     livenessProbe:
-      httpGet:
-        scheme: HTTP
-        port: 10251
-        path: healthz
-      initialDelaySeconds: 45
-      timeOutSeconds: 10
+      exec:
+        command:
+        - "/bin/bash"
+        - "-ec"
+        - |
+          find /etc/kubernetes/static-pod-resources/secrets/kube-scheduler-client-cert-key -mmin -1 -exec false {} +
+          test $(curl --silent --output /dev/stderr --write-out \"%{http_code}\" http://localhost:10251/healthz) = 200"
+      initialDelaySeconds: 70
+      timeoutSeconds: 10
+      failureThreshold: 1
     readinessProbe:
       httpGet:
         scheme: HTTP

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -314,12 +314,16 @@ spec:
     - mountPath: /etc/kubernetes/static-pod-resources
       name: resource-dir
     livenessProbe:
-      httpGet:
-        scheme: HTTP
-        port: 10251
-        path: healthz
-      initialDelaySeconds: 45
-      timeOutSeconds: 10
+      exec:
+        command:
+        - "/bin/bash"
+        - "-ec"
+        - |
+          find /etc/kubernetes/static-pod-resources/secrets/kube-scheduler-client-cert-key -mmin -1 -exec false {} +
+          test $(curl --silent --output /dev/stderr --write-out \"%{http_code}\" http://localhost:10251/healthz) = 200"
+      initialDelaySeconds: 70
+      timeoutSeconds: 10
+      failureThreshold: 1
     readinessProbe:
       httpGet:
         scheme: HTTP


### PR DESCRIPTION
We have to dynamically reload client certs in kas, kcm and ks in order to allow the cert recovery command https://github.com/openshift/cluster-kube-apiserver-operator/pull/444 to recover a broken cluster.

This is a quick and dirty way to archieve this. We plan to replace it with https://github.com/openshift/library-go/pull/392 when it is ready.