### PR TITLE
Remove degraded

### DIFF
--- a/pkg/operator/staleconditions/remove_stale_conditions.go
+++ b/pkg/operator/staleconditions/remove_stale_conditions.go
@@ -1,0 +1,116 @@
+package staleconditions
+
+import (
+	"fmt"
+	"time"
+
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+)
+
+const workQueueKey = "key"
+
+type RemoveStaleConditions struct {
+	conditions []string
+
+	operatorClient v1helpers.StaticPodOperatorClient
+	cachesToSync   []cache.InformerSynced
+
+	eventRecorder events.Recorder
+	// queue only ever has one item, but it has nice error handling backoff/retry semantics
+	queue workqueue.RateLimitingInterface
+}
+
+func NewRemoveStaleConditions(
+	conditions []string,
+	operatorClient v1helpers.StaticPodOperatorClient,
+	eventRecorder events.Recorder,
+) *RemoveStaleConditions {
+	c := &RemoveStaleConditions{
+		conditions: conditions,
+
+		operatorClient: operatorClient,
+		eventRecorder:  eventRecorder,
+		cachesToSync:   []cache.InformerSynced{operatorClient.Informer().HasSynced},
+
+		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "RemoveStaleConditions"),
+	}
+
+	operatorClient.Informer().AddEventHandler(c.eventHandler())
+
+	return c
+}
+
+func (c RemoveStaleConditions) sync() error {
+	removeStaleConditionsFn := func(status *operatorv1.StaticPodOperatorStatus) error {
+		for _, condition := range c.conditions {
+			v1helpers.RemoveOperatorCondition(&status.Conditions, condition)
+		}
+		return nil
+	}
+
+	if _, _, err := v1helpers.UpdateStaticPodStatus(c.operatorClient, removeStaleConditionsFn); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Run starts the kube-scheduler and blocks until stopCh is closed.
+func (c *RemoveStaleConditions) Run(workers int, stopCh <-chan struct{}) {
+	defer utilruntime.HandleCrash()
+	defer c.queue.ShutDown()
+
+	klog.Infof("Starting RemoveStaleConditions")
+	defer klog.Infof("Shutting down RemoveStaleConditions")
+
+	if !cache.WaitForCacheSync(stopCh, c.cachesToSync...) {
+		utilruntime.HandleError(fmt.Errorf("caches did not sync"))
+		return
+	}
+
+	// doesn't matter what workers say, only start one.
+	go wait.Until(c.runWorker, time.Second, stopCh)
+
+	<-stopCh
+}
+
+func (c *RemoveStaleConditions) runWorker() {
+	for c.processNextWorkItem() {
+	}
+}
+
+func (c *RemoveStaleConditions) processNextWorkItem() bool {
+	dsKey, quit := c.queue.Get()
+	if quit {
+		return false
+	}
+	defer c.queue.Done(dsKey)
+
+	err := c.sync()
+	if err == nil {
+		c.queue.Forget(dsKey)
+		return true
+	}
+
+	utilruntime.HandleError(fmt.Errorf("%v failed with : %v", dsKey, err))
+	c.queue.AddRateLimited(dsKey)
+
+	return true
+}
+
+// eventHandler queues the operator to check spec and status
+func (c *RemoveStaleConditions) eventHandler() cache.ResourceEventHandler {
+	return cache.ResourceEventHandlerFuncs{
+		AddFunc:    func(obj interface{}) { c.queue.Add(workQueueKey) },
+		UpdateFunc: func(old, new interface{}) { c.queue.Add(workQueueKey) },
+		DeleteFunc: func(obj interface{}) { c.queue.Add(workQueueKey) },
+	}
+}

--- a/test/e2e/scheduler_test.go
+++ b/test/e2e/scheduler_test.go
@@ -8,7 +8,11 @@ import (
 	"time"
 
 	configv1 "github.com/openshift/api/config/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
 	configv1client "github.com/openshift/client-go/config/clientset/versioned"
+	operatorversionedclient "github.com/openshift/client-go/operator/clientset/versioned"
+	operatorclientv1 "github.com/openshift/client-go/operator/clientset/versioned/typed/operator/v1"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -43,6 +47,19 @@ func getOpenShiftConfigClient() (*configv1client.Clientset, error) {
 		return nil, err
 	}
 	return configClient, nil
+}
+
+func getOpenShiftOperatorConfigClient() (*operatorversionedclient.Clientset, error) {
+	kubeconfig := os.Getenv("KUBECONFIG")
+	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	if err != nil {
+		return nil, err
+	}
+	operatorClient, err := operatorversionedclient.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+	return operatorClient, nil
 }
 
 func waitForOperator(kclient *k8sclient.Clientset) error {
@@ -157,5 +174,66 @@ func TestConfigMapCreation(t *testing.T) {
 	err = kclient.CoreV1().ConfigMaps("openshift-config").Delete("policy-configmap", nil)
 	if err != nil {
 		t.Fatalf("error waiting for config map to exist: %v\n", err)
+	}
+}
+
+func waitForOperatorToBeUpdated(opClient operatorclientv1.OperatorV1Interface, status string) error {
+	return wait.PollImmediate(1*time.Second, 5*time.Minute, func() (bool, error) {
+		schedulerConfig, err := opClient.KubeSchedulers().Get("cluster", metav1.GetOptions{})
+		if err != nil {
+			klog.Infof("Scheduler operator CR cluster doesn't exist: %v\n", err)
+			return false, nil
+		}
+		klog.Infof("Scheduler operator CR cluster exists")
+		for _, condition := range schedulerConfig.Status.Conditions {
+			if condition.Type == status {
+				return false, nil
+			}
+		}
+		return true, nil
+	})
+}
+
+// TestStaleConditionRemoval ensures that KSO returns to normal condition even if it had some degraded conditions
+// in the past
+func TestStaleConditionRemoval(t *testing.T) {
+	operatorConfigClient, err := getOpenShiftOperatorConfigClient()
+	if err != nil {
+		t.Fatalf("failed to get openshift operator client with error %v", err)
+	}
+	opClient := operatorConfigClient.OperatorV1()
+	operatorConfig, err := opClient.KubeSchedulers().Get("cluster", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to get scheduler operator config with error %v", err)
+	}
+	// Assuming the operator is not in degraded state.
+	v1helpers.SetOperatorCondition(&operatorConfig.Status.Conditions, operatorv1.OperatorCondition{
+		Type:    "Degraded",
+		Status:  operatorv1.ConditionTrue,
+		Reason:  "Synchronization error",
+		Message: "Forced Error",
+	})
+	if _, err := opClient.KubeSchedulers().UpdateStatus(operatorConfig); err != nil {
+		t.Fatalf("failed to update scheduler operator status with error %v", err)
+	}
+	if err := waitForOperatorToBeUpdated(opClient, "Degraded"); err != nil {
+		t.Fatalf("Timed out waiting for scheduler operator status to be updated")
+	}
+	operatorConfig, err = opClient.KubeSchedulers().Get("cluster", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to get scheduler operator config with error %v", err)
+	}
+	// This to test upgrade path, where older versions report
+	v1helpers.SetOperatorCondition(&operatorConfig.Status.Conditions, operatorv1.OperatorCondition{
+		Type:    "TargetConfigControllerDegraded",
+		Status:  operatorv1.ConditionTrue,
+		Reason:  "Synchronization error",
+		Message: "Forced Error",
+	})
+	if _, err := opClient.KubeSchedulers().UpdateStatus(operatorConfig); err != nil {
+		t.Fatalf("failed to update scheduler operator status with error %v", err)
+	}
+	if err := waitForOperatorToBeUpdated(opClient, "TargetConfigControllerDegraded"); err != nil {
+		t.Fatalf("Timed out waiting for scheduler operator status to be updated")
 	}
 }


### PR DESCRIPTION
Built on top of #142. 

@deads2k Added a e2e test which verifies the changes. Tested this locally, we're getting events like:

```
8m         Normal    OperatorStatusChanged        deployment/openshift-kube-scheduler-operator               Status for clusteroperator/kube-scheduler changed: Degraded message changed from "" to "Degraded: Forced Error"
10m         Normal    OperatorStatusChanged        deployment/openshift-kube-scheduler-operator               Status for clusteroperator/kube-scheduler changed: Degraded message changed from "Degraded: Forced Error" to ""
```