### PR TITLE
manifests: add ServiceMonitor for kube-scheduler

### DIFF
--- a/bindata/v3.11.0/kube-scheduler/servicemonitor.yaml
+++ b/bindata/v3.11.0/kube-scheduler/servicemonitor.yaml
@@ -1,0 +1,20 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    k8s-app: kube-scheduler
+  name: kube-scheduler
+  namespace: openshift-kube-scheduler
+spec:
+  endpoints:
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    interval: 30s
+    port: https
+    scheme: https
+    tlsConfig:
+      insecureSkipVerify: true
+  jobLabel: null
+  namespaceSelector:
+    matchNames:
+    - openshift-kube-scheduler
+  selector: {}

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -13,6 +13,7 @@
 // bindata/v3.11.0/kube-scheduler/policyconfigmap-rolebinding.yaml
 // bindata/v3.11.0/kube-scheduler/sa.yaml
 // bindata/v3.11.0/kube-scheduler/scheduler-clusterrolebinding.yaml
+// bindata/v3.11.0/kube-scheduler/servicemonitor.yaml
 // bindata/v3.11.0/kube-scheduler/svc.yaml
 // DO NOT EDIT!
 
@@ -471,6 +472,43 @@ func v3110KubeSchedulerSchedulerClusterrolebindingYaml() (*asset, error) {
 	return a, nil
 }
 
+var _v3110KubeSchedulerServicemonitorYaml = []byte(`apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    k8s-app: kube-scheduler
+  name: kube-scheduler
+  namespace: openshift-kube-scheduler
+spec:
+  endpoints:
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    interval: 30s
+    port: https
+    scheme: https
+    tlsConfig:
+      insecureSkipVerify: true
+  jobLabel: null
+  namespaceSelector:
+    matchNames:
+    - openshift-kube-scheduler
+  selector: {}
+`)
+
+func v3110KubeSchedulerServicemonitorYamlBytes() ([]byte, error) {
+	return _v3110KubeSchedulerServicemonitorYaml, nil
+}
+
+func v3110KubeSchedulerServicemonitorYaml() (*asset, error) {
+	bytes, err := v3110KubeSchedulerServicemonitorYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "v3.11.0/kube-scheduler/servicemonitor.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
 var _v3110KubeSchedulerSvcYaml = []byte(`apiVersion: v1
 kind: Service
 metadata:
@@ -569,6 +607,7 @@ var _bindata = map[string]func() (*asset, error){
 	"v3.11.0/kube-scheduler/policyconfigmap-rolebinding.yaml":             v3110KubeSchedulerPolicyconfigmapRolebindingYaml,
 	"v3.11.0/kube-scheduler/sa.yaml":                                      v3110KubeSchedulerSaYaml,
 	"v3.11.0/kube-scheduler/scheduler-clusterrolebinding.yaml":            v3110KubeSchedulerSchedulerClusterrolebindingYaml,
+	"v3.11.0/kube-scheduler/servicemonitor.yaml":                          v3110KubeSchedulerServicemonitorYaml,
 	"v3.11.0/kube-scheduler/svc.yaml":                                     v3110KubeSchedulerSvcYaml,
 }
 
@@ -628,6 +667,7 @@ var _bintree = &bintree{nil, map[string]*bintree{
 			"policyconfigmap-rolebinding.yaml":             {v3110KubeSchedulerPolicyconfigmapRolebindingYaml, map[string]*bintree{}},
 			"sa.yaml":                                      {v3110KubeSchedulerSaYaml, map[string]*bintree{}},
 			"scheduler-clusterrolebinding.yaml":            {v3110KubeSchedulerSchedulerClusterrolebindingYaml, map[string]*bintree{}},
+			"servicemonitor.yaml":                          {v3110KubeSchedulerServicemonitorYaml, map[string]*bintree{}},
 			"svc.yaml":                                     {v3110KubeSchedulerSvcYaml, map[string]*bintree{}},
 		}},
 	}},


### PR DESCRIPTION
Since each team should own their monitoring configuration we are removing ServiceMonitor manifests from cluster-monitoring-operator.

Related to openshift/cluster-monitoring-operator#391

/cc @brancz @sttts