### PR TITLE
bindata/bootkube: use loopback kubeconfig to talk to API

### DIFF
--- a/bindata/bootkube/bootstrap-manifests/kube-scheduler-pod.yaml
+++ b/bindata/bootkube/bootstrap-manifests/kube-scheduler-pod.yaml
@@ -15,7 +15,7 @@ spec:
     imagePullPolicy: {{ .ImagePullPolicy }}
     command: ["/bin/bash", "-c"]
     args:
-    - exec hyperkube kube-scheduler --kubeconfig=/etc/kubernetes/secrets/kubeconfig --leader-elect=true --cert-dir=/var/run/kubernetes --port 0 --authentication-kubeconfig=/etc/kubernetes/secrets/kubeconfig --authorization-kubeconfig=/etc/kubernetes/secrets/kubeconfig
+    - exec hyperkube kube-scheduler --kubeconfig=/etc/kubernetes/secrets/kubeconfig-loopback --leader-elect=true --cert-dir=/var/run/kubernetes --port 0 --authentication-kubeconfig=/etc/kubernetes/secrets/kubeconfig-loopback --authorization-kubeconfig=/etc/kubernetes/secrets/kubeconfig-loopback
     volumeMounts:
     - mountPath: /etc/kubernetes/secrets
       name: secrets

--- a/bindata/bootkube/config/bootstrap-config-overrides.yaml
+++ b/bindata/bootkube/config/bootstrap-config-overrides.yaml
@@ -1,2 +1,7 @@
 apiVersion: kubescheduler.config.k8s.io/v1alpha1
 kind: KubeSchedulerConfiguration
+extendedArguments:
+  authentication-kubeconfig:
+  - "/etc/kubernetes/secrets/kubeconfig-loopback"
+  authorization-kubeconfig:
+  - "/etc/kubernetes/secrets/kubeconfig-loopback"


### PR DESCRIPTION
This code modifies cluster-kube-scheduler-operator to use a kubeconfig configured for localhost API access. 

This is necessary due to a limitation with Azure internal load balancers. See limitation #2 here: https://docs.microsoft.com/en-us/azure/load-balancer/load-balancer-overview#limitations

"Unlike public Load Balancers which provide outbound connections when transitioning from private IP addresses inside the virtual network to public IP addresses, internal Load Balancers do not translate outbound originated connections to the frontend of an internal Load Balancer as both are in private IP address space. This avoids potential for SNAT port exhaustion inside unique internal IP address space where translation is not required. The side effect is that if an outbound flow from a VM in the backend pool attempts a flow to frontend of the internal Load Balancer in which pool it resides and is mapped back to itself, both legs of the flow don't match and the flow will fail."

kubeconfig-loopback is generated by the installer.

https://jira.coreos.com/browse/CORS-1094