### PR TITLE
Bug 1749457: Add master_schedulable metric

### DIFF
--- a/pkg/operator/configmetrics/configmetrics.go
+++ b/pkg/operator/configmetrics/configmetrics.go
@@ -1,0 +1,42 @@
+package configmetrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+
+	configinformers "github.com/openshift/client-go/config/informers/externalversions"
+	configlisters "github.com/openshift/client-go/config/listers/config/v1"
+)
+
+func Register(configInformer configinformers.SharedInformerFactory) {
+	prometheus.MustRegister(&configMetrics{
+		configLister: configInformer.Config().V1().Schedulers().Lister(),
+		config: prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "cluster_master_schedulable",
+			Help: "Reports whether the cluster master nodes are schedulable.",
+		}),
+	})
+}
+
+// configMetrics implements metrics gathering for this component.
+type configMetrics struct {
+	configLister configlisters.SchedulerLister
+	config       prometheus.Gauge
+}
+
+// Describe reports the metadata for metrics to the prometheus collector.
+func (m *configMetrics) Describe(ch chan<- *prometheus.Desc) {
+	ch <- m.config.Desc()
+}
+
+// Collect calculates metrics from the cached config and reports them to the prometheus collector.
+func (m *configMetrics) Collect(ch chan<- prometheus.Metric) {
+	if config, err := m.configLister.Get("cluster"); err == nil {
+		var g prometheus.Gauge
+		var value float64
+		if config.Spec.MastersSchedulable {
+			value = 1
+		}
+		g.Set(value)
+		ch <- g
+	}
+}

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -16,6 +16,7 @@ import (
 	configv1client "github.com/openshift/client-go/config/clientset/versioned"
 	configv1informers "github.com/openshift/client-go/config/informers/externalversions"
 	operatorversionedclient "github.com/openshift/client-go/operator/clientset/versioned"
+	"github.com/openshift/cluster-kube-scheduler-operator/pkg/operator/configmetrics"
 	"github.com/openshift/cluster-kube-scheduler-operator/pkg/operator/configobservation/configobservercontroller"
 	"github.com/openshift/cluster-kube-scheduler-operator/pkg/operator/operatorclient"
 	"github.com/openshift/cluster-kube-scheduler-operator/pkg/operator/resourcesynccontroller"
@@ -144,6 +145,8 @@ func RunOperator(ctx *controllercmd.ControllerContext) error {
 		operatorClient,
 		ctx.EventRecorder,
 	)
+
+	configmetrics.Register(configInformers)
 
 	kubeInformersClusterScoped.Start(ctx.Done())
 	kubeInformersNamespace.Start(ctx.Done())


### PR DESCRIPTION
This adds metrics reporting to the kube-scheduler operator, specifically it will report a 1 or 0 for if masters are schedulable under the metric `cluster_master_schedulable`

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1749457