### PR TITLE
Bug 1745671: Do not register event handlers twice for configmaps under openshift-kube-scheduler

### DIFF
--- a/pkg/operator/target_config_reconciler.go
+++ b/pkg/operator/target_config_reconciler.go
@@ -68,7 +68,6 @@ func NewTargetConfigReconciler(
 	configInformer.Config().V1().FeatureGates().Informer().AddEventHandler(c.eventHandler())
 	// we react to some config changes
 	kubeInformersForNamespaces.InformersFor(operatorclient.GlobalUserSpecifiedConfigNamespace).Core().V1().ConfigMaps().Informer().AddEventHandler(c.eventHandler())
-	kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace).Core().V1().ConfigMaps().Informer().AddEventHandler(c.eventHandler())
 
 	// we only watch some namespaces
 	namespacedKubeInformers.Core().V1().Namespaces().Informer().AddEventHandler(c.namespaceEventHandler())


### PR DESCRIPTION
Reducing the number of syncs of TargetConfigReconciler to half.

Rates reduced to:
* configmaps: ~2
* rolebindings: ~1
* secrets: ~0.5