### PR TITLE
Fix scheduler metrics

### DIFF
--- a/manifests/0000_90_kube-scheduler-operator_04_servicemonitor-scheduler.yaml
+++ b/manifests/0000_90_kube-scheduler-operator_04_servicemonitor-scheduler.yaml
@@ -12,7 +12,8 @@ spec:
     port: https
     scheme: https
     tlsConfig:
-      insecureSkipVerify: true
+      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+      serverName: scheduler.openshift-kube-scheduler.svc
   namespaceSelector:
     matchNames:
     - openshift-kube-scheduler

--- a/pkg/operator/configmetrics/configmetrics.go
+++ b/pkg/operator/configmetrics/configmetrics.go
@@ -1,14 +1,16 @@
 package configmetrics
 
 import (
+	"github.com/blang/semver"
 	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/component-base/metrics/legacyregistry"
 
 	configinformers "github.com/openshift/client-go/config/informers/externalversions"
 	configlisters "github.com/openshift/client-go/config/listers/config/v1"
 )
 
 func Register(configInformer configinformers.SharedInformerFactory) {
-	prometheus.MustRegister(&configMetrics{
+	legacyregistry.MustRegister(&configMetrics{
 		configLister: configInformer.Config().V1().Schedulers().Lister(),
 		config: prometheus.NewGauge(prometheus.GaugeOpts{
 			Name: "cluster_master_schedulable",
@@ -21,6 +23,10 @@ func Register(configInformer configinformers.SharedInformerFactory) {
 type configMetrics struct {
 	configLister configlisters.SchedulerLister
 	config       prometheus.Gauge
+}
+
+func (m *configMetrics) Create(version *semver.Version) bool {
+	return true
 }
 
 // Describe reports the metadata for metrics to the prometheus collector.


### PR DESCRIPTION
* First commit will make metrics collection from scheduler secure
* Second commit will switch to use `legacyregistry` for metrics collection