### PR TITLE
Add manifest annotations for hosted deployment exclusions

### DIFF
--- a/manifests/0000_25_kube-scheduler-operator_02_service.yaml
+++ b/manifests/0000_25_kube-scheduler-operator_02_service.yaml
@@ -3,6 +3,7 @@ kind: Service
 metadata:
   annotations:
     service.alpha.openshift.io/serving-cert-secret-name: kube-scheduler-operator-serving-cert
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
   labels:
     app: openshift-kube-scheduler-operator
   name: metrics

--- a/manifests/0000_25_kube-scheduler-operator_06_deployment.yaml
+++ b/manifests/0000_25_kube-scheduler-operator_06_deployment.yaml
@@ -5,6 +5,8 @@ metadata:
   name: openshift-kube-scheduler-operator
   labels:
     app: openshift-kube-scheduler-operator
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 spec:
   replicas: 1
   selector:

--- a/manifests/0000_25_kube-scheduler-operator_07_clusteroperator.yaml
+++ b/manifests/0000_25_kube-scheduler-operator_07_clusteroperator.yaml
@@ -2,6 +2,8 @@ apiVersion: config.openshift.io/v1
 kind: ClusterOperator
 metadata:
   name: kube-scheduler
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 spec: {}
 status:
   versions:

--- a/manifests/0000_90_kube-scheduler-operator_03_servicemonitor.yaml
+++ b/manifests/0000_90_kube-scheduler-operator_03_servicemonitor.yaml
@@ -3,6 +3,8 @@ kind: ServiceMonitor
 metadata:
   name: kube-scheduler-operator
   namespace: openshift-kube-scheduler-operator
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 spec:
   endpoints:
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
@@ -30,6 +32,8 @@ kind: PrometheusRule
 metadata:
   name: kube-scheduler-operator
   namespace: openshift-kube-scheduler-operator
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 spec:
   groups:
   - name: cluster-version

--- a/manifests/0000_90_kube-scheduler-operator_04_servicemonitor-scheduler.yaml
+++ b/manifests/0000_90_kube-scheduler-operator_04_servicemonitor-scheduler.yaml
@@ -5,6 +5,8 @@ metadata:
     k8s-app: kube-scheduler
   name: kube-scheduler
   namespace: openshift-kube-scheduler
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 spec:
   endpoints:
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token


### PR DESCRIPTION
Enables the CVO to exclude manifests in an externally hosted control plane deployment
See https://github.com/openshift/cluster-version-operator/pull/252