### PR TITLE
bug 1798725: static pod operator cannot be composed

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/jteeuwen/go-bindata v3.0.8-0.20151023091102-a0ff2567cfb7+incompatible
 	github.com/openshift/api v0.0.0-20200116145750-0e2ff1e215dd
 	github.com/openshift/client-go v0.0.0-20200116152001-92a2713fa240
-	github.com/openshift/library-go v0.0.0-20200127211524-05e7d57f0ed3
+	github.com/openshift/library-go v0.0.0-20200205212311-6f4b8eee2d65
 	github.com/prometheus/client_golang v1.1.0
 	github.com/prometheus/common v0.6.0
 	github.com/spf13/cobra v0.0.5

--- a/go.sum
+++ b/go.sum
@@ -287,8 +287,8 @@ github.com/openshift/api v0.0.0-20200116145750-0e2ff1e215dd h1:WIrzR6PXOptxWGafi
 github.com/openshift/api v0.0.0-20200116145750-0e2ff1e215dd/go.mod h1:fT6U/JfG8uZzemTRwZA2kBDJP5nWz7v05UHnty/D+pk=
 github.com/openshift/client-go v0.0.0-20200116152001-92a2713fa240 h1:XYfJWv2Ch+qInGLDEedHRtDsJwnxyU1L8U7SY56NcA8=
 github.com/openshift/client-go v0.0.0-20200116152001-92a2713fa240/go.mod h1:4riOwdj99Hd/q+iAcJZfNCsQQQMwURnZV6RL4WHYS5w=
-github.com/openshift/library-go v0.0.0-20200127211524-05e7d57f0ed3 h1:4rOhpq6pmriw+yCIZHBY9g0VDZvqlu8/hc7goVeBLtM=
-github.com/openshift/library-go v0.0.0-20200127211524-05e7d57f0ed3/go.mod h1:/P1rPwPkaaNtylv8PLYkOTbf6tCdaNYDNqL9Y8GzJfE=
+github.com/openshift/library-go v0.0.0-20200205212311-6f4b8eee2d65 h1:rL5n5b9aaTxEInHMAcvbgJKvszXNAI6bfVN3OybHKyc=
+github.com/openshift/library-go v0.0.0-20200205212311-6f4b8eee2d65/go.mod h1:/P1rPwPkaaNtylv8PLYkOTbf6tCdaNYDNqL9Y8GzJfE=
 github.com/pborman/uuid v1.2.0 h1:J7Q5mO4ysT1dv8hyrUGHb9+ooztCXu1D8MY8DZYsu3g=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -6,10 +6,6 @@ import (
 	"os"
 	"time"
 
-	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
-
 	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	configv1client "github.com/openshift/client-go/config/clientset/versioned"
@@ -25,6 +21,9 @@ import (
 	"github.com/openshift/library-go/pkg/operator/staticpod/controller/revision"
 	"github.com/openshift/library-go/pkg/operator/status"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 )
 
 const (
@@ -123,8 +122,9 @@ func RunOperator(ctx context.Context, cc *controllercmd.ControllerContext) error
 
 	staleConditions := staleconditions.NewRemoveStaleConditions(
 		[]string{
-			// in 4.1.0 this was accidentally in the list.  This can be removed in 4.3.
-			"Degraded",
+			// the static pod operator used to directly set these. this removes those conditions since the static pod operator was updated.
+			// these can be removed in 4.5
+			"Available", "Progressing",
 		},
 		operatorClient,
 		cc.EventRecorder,

--- a/vendor/github.com/openshift/library-go/alpha-build-machinery/make/lib/golang.mk
+++ b/vendor/github.com/openshift/library-go/alpha-build-machinery/make/lib/golang.mk
@@ -1,7 +1,10 @@
-GO ?=go
-GOPATH ?=$(shell $(GO) env GOPATH)
-GO_PACKAGE ?=$(shell $(GO) list -m -f '{{ .Path }}' || echo 'no_package_detected')
+include $(addprefix $(dir $(lastword $(MAKEFILE_LIST))), \
+	version.mk \
+)
 
+GO ?=go
+
+GOPATH ?=$(shell $(GO) env GOPATH)
 GOOS ?=$(shell $(GO) env GOOS)
 GOHOSTOS ?=$(shell $(GO) env GOHOSTOS)
 GOARCH ?=$(shell $(GO) env GOARCH)
@@ -13,9 +16,11 @@ GOFMT ?=gofmt
 GOFMT_FLAGS ?=-s -l
 GOLINT ?=golint
 
-GO_FILES ?=$(shell find . -name '*.go' -not -path '*/vendor/*' -not -path '*/_output/*' -print)
-GO_PACKAGES ?=./...
-GO_TEST_PACKAGES ?=$(GO_PACKAGES)
+go_version :=$(shell $(GO) version | sed -E -e 's/.*go([0-9]+.[0-9]+.[0-9]+).*/\1/')
+GO_REQUIRED_MIN_VERSION ?=1.13.5
+ifneq "$(GO_REQUIRED_MIN_VERSION)" ""
+$(call require_minimal_version,$(GO),GO_REQUIRED_MIN_VERSION,$(go_version))
+endif
 
 # Projects not using modules can clear the variable, but by default we want to prevent
 # our projects with modules to unknowingly ignore vendor folder until golang is fixed to use
@@ -29,10 +34,16 @@ else
 GO_MOD_FLAGS ?=-mod=vendor
 endif
 
+GO_PACKAGE ?=$(shell $(GO) list $(GO_MOD_FLAGS) -m -f '{{ .Path }}' || echo 'no_package_detected')
+GO_PACKAGES ?=./...
+GO_TEST_PACKAGES ?=$(GO_PACKAGES)
+GO_FILES ?=$(shell find . -name '*.go' -not -path '*/vendor/*' -not -path '*/_output/*' -print)
+
+
 GO_BUILD_PACKAGES ?=./cmd/...
 GO_BUILD_PACKAGES_EXPANDED ?=$(shell $(GO) list $(GO_MOD_FLAGS) $(GO_BUILD_PACKAGES))
 go_build_binaries =$(notdir $(GO_BUILD_PACKAGES_EXPANDED))
-GO_BUILD_FLAGS ?=
+GO_BUILD_FLAGS ?=-trimpath
 GO_BUILD_BINDIR ?=
 
 GO_TEST_FLAGS ?=-race

--- a/vendor/github.com/openshift/library-go/alpha-build-machinery/make/lib/version.mk
+++ b/vendor/github.com/openshift/library-go/alpha-build-machinery/make/lib/version.mk
@@ -1,0 +1,14 @@
+# $1 - required version
+# $2 - current version
+define is_equal_or_higher_version
+$(strip $(filter $(2),$(firstword $(shell set -euo pipefail && echo -e '$(1)\n$(2)' | sort -V -r -b))))
+endef
+
+# $1 - program name
+# $2 - required version variable name
+# $3 - current version string
+define require_minimal_version
+$(if $($(2)),\
+$(if $(strip $(call is_equal_or_higher_version,$($(2)),$(3))),,$(error `$(1)` is required with minimal version "$($(2))", detected version "$(3)". You can override this check by using `make $(2):=`)),\
+)
+endef

--- a/vendor/github.com/openshift/library-go/alpha-build-machinery/make/targets/golang/build.mk
+++ b/vendor/github.com/openshift/library-go/alpha-build-machinery/make/targets/golang/build.mk
@@ -10,6 +10,7 @@ endef
 
 # We need to build each package separately so go build creates appropriate binaries
 build:
+	$(if $(strip $(GO_BUILD_PACKAGES_EXPANDED)),,$(error no packages to build: GO_BUILD_PACKAGES_EXPANDED var is empty))
 	$(foreach package,$(GO_BUILD_PACKAGES_EXPANDED),$(call build-package,$(package)))
 .PHONY: build
 

--- a/vendor/github.com/openshift/library-go/alpha-build-machinery/make/targets/openshift/crd-schema-gen.mk
+++ b/vendor/github.com/openshift/library-go/alpha-build-machinery/make/targets/openshift/crd-schema-gen.mk
@@ -39,7 +39,7 @@ update-codegen-crds-$(1): ensure-controller-gen ensure-yq
 update-codegen-crds: update-codegen-crds-$(1)
 .PHONY: update-codegen-crds
 
-verify-codegen-crds-$(1): VERIFY_CODEGEN_CRD_TMP_DIR:=$(shell mktemp -d)
+verify-codegen-crds-$(1): VERIFY_CODEGEN_CRD_TMP_DIR:=$$(shell mktemp -d)
 verify-codegen-crds-$(1): ensure-controller-gen ensure-yq
 	$(call run-crd-gen,$(2),$(3),$$(VERIFY_CODEGEN_CRD_TMP_DIR))
 	$$(foreach p,$$(wildcard $(3)/*.crd.yaml),$$(call diff-file,$$(p),$$(subst $(3),$$(VERIFY_CODEGEN_CRD_TMP_DIR),$$(p))))

--- a/vendor/github.com/openshift/library-go/alpha-build-machinery/make/targets/openshift/deps.mk
+++ b/vendor/github.com/openshift/library-go/alpha-build-machinery/make/targets/openshift/deps.mk
@@ -6,7 +6,7 @@ include $(addprefix $(self_dir), \
 	../../lib/golang.mk \
 )
 
-ifneq "$(GO) list -m" ""
+ifneq "$(GO) list $(GO_MOD_FLAGS) -m" ""
 include $(deps_gomod_mkfile)
 else
 include $(deps_glide_mkfile)

--- a/vendor/github.com/openshift/library-go/pkg/controller/factory/base_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/controller/factory/base_controller.go
@@ -1,0 +1,127 @@
+package factory
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog"
+)
+
+// baseController represents generic Kubernetes controller boiler-plate
+type baseController struct {
+	name         string
+	cachesToSync []cache.InformerSynced
+	sync         func(ctx context.Context, controllerContext SyncContext) error
+	resyncEvery  time.Duration
+	syncContext  SyncContext
+}
+
+var _ Controller = &baseController{}
+
+func (c *baseController) Run(ctx context.Context, workers int) {
+	// HandleCrash recovers panics
+	defer utilruntime.HandleCrash()
+	if !cache.WaitForNamedCacheSync(c.name, ctx.Done(), c.cachesToSync...) {
+		panic("timeout waiting for informer cache") // this will be recovered using HandleCrash()
+	}
+
+	var workerWaitGroup sync.WaitGroup
+	defer func() {
+		defer klog.Infof("All %s workers have been terminated", c.name)
+		workerWaitGroup.Wait()
+	}()
+
+	// queueContext is used to track and initiate queue shutdown
+	queueContext, queueContextCancel := context.WithCancel(context.TODO())
+
+	for i := 1; i <= workers; i++ {
+		klog.Infof("Starting #%d worker of %s controller ...", i, c.name)
+		workerWaitGroup.Add(1)
+		go func() {
+			defer func() {
+				klog.Infof("Shutting down worker of %s controller ...", c.name)
+				workerWaitGroup.Done()
+			}()
+			c.runWorker(queueContext)
+		}()
+	}
+
+	// runPeriodicalResync is independent from queue
+	if c.resyncEvery > 0 {
+		workerWaitGroup.Add(1)
+		go func() {
+			defer workerWaitGroup.Done()
+			c.runPeriodicalResync(ctx, c.resyncEvery)
+		}()
+	}
+
+	// Handle controller shutdown
+
+	<-ctx.Done()                     // wait for controller context to be cancelled
+	c.syncContext.Queue().ShutDown() // shutdown the controller queue first
+	queueContextCancel()             // cancel the queue context, which tell workers to initiate shutdown
+
+	// Wait for all workers to finish their job.
+	// at this point the Run() can hang and caller have to implement the logic that will kill
+	// this controller (SIGKILL).
+	klog.Infof("Shutting down %s ...", c.name)
+}
+
+func (c *baseController) Sync(ctx context.Context, syncCtx SyncContext) error {
+	return c.sync(ctx, syncCtx)
+}
+
+// QueueKey return queue key for given name.
+func QueueKey(name string) string {
+	return strings.ToLower(name) + "Key"
+}
+
+func (c *baseController) runPeriodicalResync(ctx context.Context, interval time.Duration) {
+	go wait.UntilWithContext(ctx, func(ctx context.Context) {
+		c.syncContext.Queue().Add(QueueKey(c.name))
+	}, interval)
+}
+
+// runWorker runs a single worker
+// The worker is asked to terminate when the passed context is cancelled and is given terminationGraceDuration time
+// to complete its shutdown.
+func (c *baseController) runWorker(queueCtx context.Context) {
+	var workerWaitGroup sync.WaitGroup
+	workerWaitGroup.Add(1)
+	go func() {
+		defer workerWaitGroup.Done()
+		for {
+			select {
+			case <-queueCtx.Done():
+				return
+			default:
+				c.processNextWorkItem(queueCtx)
+			}
+		}
+	}()
+	workerWaitGroup.Wait()
+}
+
+func (c *baseController) processNextWorkItem(queueCtx context.Context) {
+	syncObject, quit := c.syncContext.Queue().Get()
+	if quit {
+		return
+	}
+	defer c.syncContext.Queue().Done(syncObject)
+
+	runtimeObject, _ := syncObject.(runtime.Object)
+	if err := c.sync(queueCtx, c.syncContext.(syncContext).withRuntimeObject(runtimeObject)); err != nil {
+		utilruntime.HandleError(fmt.Errorf("%s controller failed to sync %+v with: %w", c.name, syncObject, err))
+		c.syncContext.Queue().AddRateLimited(syncObject)
+		return
+	}
+
+	c.syncContext.Queue().Forget(syncObject)
+}

--- a/vendor/github.com/openshift/library-go/pkg/controller/factory/controller_context.go
+++ b/vendor/github.com/openshift/library-go/pkg/controller/factory/controller_context.go
@@ -1,0 +1,154 @@
+package factory
+
+import (
+	"fmt"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+
+	"github.com/openshift/library-go/pkg/operator/events"
+)
+
+// syncContext implements SyncContext and provide user access to queue and object that caused
+// the sync to be triggered.
+type syncContext struct {
+	queue         workqueue.RateLimitingInterface
+	eventRecorder events.Recorder
+
+	// queueRuntimeObject holds the object we got from informer
+	// There is no direct access to this object to prevent cache mutation.
+	queueRuntimeObject runtime.Object
+}
+
+var _ SyncContext = syncContext{}
+
+// NewSyncContext gives new sync context.
+func NewSyncContext(name string, recorder events.Recorder) SyncContext {
+	return syncContext{
+		queue:         workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), name),
+		eventRecorder: recorder.WithComponentSuffix(strings.ToLower(name)),
+	}
+}
+
+// GetObject gives the object from the queue.
+// For controllers generated without WithRuntimeObject() this always return nil.
+func (c syncContext) GetObject() runtime.Object {
+	if c.queueRuntimeObject == nil {
+		return nil
+	}
+	return c.queueRuntimeObject.DeepCopyObject()
+}
+
+func (c syncContext) Queue() workqueue.RateLimitingInterface {
+	return c.queue
+}
+
+func (c syncContext) Recorder() events.Recorder {
+	return c.eventRecorder
+}
+
+// withRuntimeObject make a copy of existing sync context and set the queueRuntimeObject.
+func (c syncContext) withRuntimeObject(obj runtime.Object) SyncContext {
+	return syncContext{
+		eventRecorder:      c.Recorder(),
+		queue:              c.Queue(),
+		queueRuntimeObject: obj,
+	}
+}
+
+func (c syncContext) isInterestingNamespace(obj interface{}, interestingNamespaces sets.String) (bool, bool) {
+	ns, ok := obj.(*corev1.Namespace)
+	if !ok {
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if ok {
+			if ns, ok := tombstone.Obj.(*corev1.Namespace); ok {
+				return true, interestingNamespaces.Has(ns.Name)
+			}
+		}
+		return false, false
+	}
+	return true, interestingNamespaces.Has(ns.Name)
+}
+
+// eventHandler provides default event handler that is added to an informers passed to controller factory.
+func (c syncContext) eventHandler(keyName string, objectQueue bool, interestingNamespaces sets.String) cache.ResourceEventHandler {
+	return cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			isNamespace, isInteresting := c.isInterestingNamespace(obj, interestingNamespaces)
+			if !objectQueue {
+				if !isNamespace {
+					c.Queue().Add(keyName)
+				} else if isInteresting {
+					c.Queue().Add(keyName)
+				}
+				return
+			}
+			runtimeObj, ok := obj.(runtime.Object)
+			if !ok {
+				utilruntime.HandleError(fmt.Errorf("added object %+v is not runtime Object", obj))
+				return
+			}
+			if !isNamespace {
+				c.Queue().Add(runtimeObj)
+			} else if isInteresting {
+				c.Queue().Add(runtimeObj)
+			}
+		},
+		UpdateFunc: func(old, new interface{}) {
+			isNamespace, isInteresting := c.isInterestingNamespace(new, interestingNamespaces)
+			if !objectQueue {
+				if !isNamespace {
+					c.Queue().Add(keyName)
+				} else if isInteresting {
+					c.Queue().Add(keyName)
+				}
+				return
+			}
+			runtimeObj, ok := new.(runtime.Object)
+			if !ok {
+				utilruntime.HandleError(fmt.Errorf("updated object %+v is not runtime Object", runtimeObj))
+				return
+			}
+			if !isNamespace {
+				c.Queue().Add(runtimeObj)
+			} else if isInteresting {
+				c.Queue().Add(runtimeObj)
+			}
+		},
+		DeleteFunc: func(obj interface{}) {
+			isNamespace, isInteresting := c.isInterestingNamespace(obj, interestingNamespaces)
+			if !objectQueue {
+				if !isNamespace {
+					c.Queue().Add(keyName)
+				} else if isInteresting {
+					c.Queue().Add(keyName)
+				}
+				return
+			}
+			runtimeObj, ok := obj.(runtime.Object)
+			if !ok {
+				tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+				if ok {
+					if !isNamespace {
+						c.Queue().Add(tombstone.Obj.(runtime.Object))
+					} else if isInteresting {
+						c.Queue().Add(tombstone.Obj.(runtime.Object))
+					}
+					return
+				}
+				utilruntime.HandleError(fmt.Errorf("updated object %+v is not runtime Object", runtimeObj))
+				return
+			}
+			if !isNamespace {
+				c.Queue().Add(runtimeObj)
+			} else if isInteresting {
+				c.Queue().Add(runtimeObj)
+			}
+		},
+	}
+}

--- a/vendor/github.com/openshift/library-go/pkg/controller/factory/factory.go
+++ b/vendor/github.com/openshift/library-go/pkg/controller/factory/factory.go
@@ -1,0 +1,104 @@
+package factory
+
+import (
+	"strings"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/openshift/library-go/pkg/operator/events"
+)
+
+// Factory is generator that generate standard Kubernetes controllers.
+// Factory is really generic and should be only used for simple controllers that does not require special stuff..
+type Factory struct {
+	sync                  SyncFunc
+	resyncInterval        time.Duration
+	objectQueue           bool
+	informers             []cache.SharedInformer
+	namespaceInformers    []*namespaceInformer
+	cachesToSync          []cache.InformerSynced
+	interestingNamespaces sets.String
+}
+
+type namespaceInformer struct {
+	informer   cache.SharedInformer
+	namespaces sets.String
+}
+
+// New return new factory instance.
+func New() *Factory {
+	return &Factory{}
+}
+
+// Sync is used to set the controller synchronization function. This function is the core of the controller and is
+// usually hold the main controller logic.
+func (f *Factory) WithSync(syncFn SyncFunc) *Factory {
+	f.sync = syncFn
+	return f
+}
+
+// WithInformers is used to register event handlers and get the caches synchronized functions.
+// Pass informers you want to use to react to changes on resources. If informer event is observed, then the Sync() function
+// is called.
+func (f *Factory) WithInformers(informers ...cache.SharedInformer) *Factory {
+	f.informers = append(f.informers, informers...)
+	return f
+}
+
+// WithNamespaceInformer is used to register event handlers and get the caches synchronized functions.
+// The sync function will only trigger when the object observed by this informer is a namespace and its name matches the interestingNamespaces.
+// Do not use this to register non-namespace informers.
+func (f *Factory) WithNamespaceInformer(informer cache.SharedInformer, interestingNamespaces ...string) *Factory {
+	f.namespaceInformers = append(f.namespaceInformers, &namespaceInformer{
+		informer:   informer,
+		namespaces: sets.NewString(interestingNamespaces...),
+	})
+	return f
+}
+
+// ResyncEvery will cause the Sync() function to be called periodically, regardless of informers.
+// This is useful when you want to refresh every N minutes or you fear that your informers can be stucked.
+// If this is not called, no periodical resync will happen.
+// Note: The controller context passed to Sync() function in this case does not contain the object metadata or object itself.
+//       This can be used to detect periodical resyncs, but normal Sync() have to be cautious about `nil` objects.
+func (f *Factory) ResyncEvery(interval time.Duration) *Factory {
+	f.resyncInterval = interval
+	return f
+}
+
+// WithRuntimeObject cause the factory to produce controller that pass the runtime.Object from event handler that was
+// triggered to queue (instead of requeue using simple string key). This allow to access this object, however storing
+// object in queue might increase memory usage (?).
+func (f *Factory) WithRuntimeObject() *Factory {
+	f.objectQueue = true
+	return f
+}
+
+// Controller produce a runnable controller.
+func (f *Factory) ToController(name string, eventRecorder events.Recorder) Controller {
+	if f.sync == nil {
+		panic("Sync() function must be called before making controller")
+	}
+
+	ctx := NewSyncContext(name, eventRecorder)
+	c := &baseController{
+		name:        name,
+		sync:        f.sync,
+		resyncEvery: f.resyncInterval,
+		syncContext: ctx,
+	}
+
+	for i := range f.informers {
+		f.informers[i].AddEventHandler(c.syncContext.(syncContext).eventHandler(strings.ToLower(name)+"Key", f.objectQueue, sets.NewString()))
+		c.cachesToSync = append(f.cachesToSync, f.informers[i].HasSynced)
+	}
+
+	for i := range f.namespaceInformers {
+		f.namespaceInformers[i].informer.AddEventHandler(c.syncContext.(syncContext).eventHandler(strings.ToLower(name)+"Key", f.objectQueue, f.namespaceInformers[i].namespaces))
+		c.cachesToSync = append(f.cachesToSync, f.informers[i].HasSynced)
+	}
+
+	return c
+}

--- a/vendor/github.com/openshift/library-go/pkg/controller/factory/interfaces.go
+++ b/vendor/github.com/openshift/library-go/pkg/controller/factory/interfaces.go
@@ -1,0 +1,46 @@
+package factory
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/util/workqueue"
+
+	"github.com/openshift/library-go/pkg/operator/events"
+)
+
+// Controller interface represents a runnable Kubernetes controller.
+// Cancelling the syncContext passed will cause the controller to shutdown.
+// Number of workers determine how much parallel the job processing should be.
+type Controller interface {
+	// Run runs the controller and blocks until the controller is finished.
+	// Number of workers can be specified via workers parameter.
+	// This function will return when all internal loops are finished.
+	// Note that having more than one worker usually means handing parallelization of Sync().
+	Run(ctx context.Context, workers int)
+
+	// Sync contain the main controller logic.
+	// This should not be called directly, but can be used in unit tests to exercise the sync.
+	Sync(ctx context.Context, controllerContext SyncContext) error
+}
+
+// SyncContext interface represents a context given to the Sync() function where the main controller logic happen.
+// SyncContext exposes controller name and give user access to the queue (for manual requeue).
+// SyncContext also provides metadata about object that informers observed as changed.
+type SyncContext interface {
+	// Queue gives access to controller queue. This can be used for manual requeue, although if a Sync() function return
+	// an error, the object is automatically re-queued. Use with caution.
+	Queue() workqueue.RateLimitingInterface
+
+	// GetObject provides access to current synced object deep copy.
+	// It is safe to mutate this object inside Sync().
+	GetObject() runtime.Object
+
+	// Recorder provide access to event recorder.
+	Recorder() events.Recorder
+}
+
+// SyncFunc is a function that contain main controller logic.
+// The syncContext.syncContext passed is the main controller syncContext, when cancelled it means the controller is being shut down.
+// The syncContext provides access to controller name, queue and event recorder.
+type SyncFunc func(ctx context.Context, controllerContext SyncContext) error

--- a/vendor/github.com/openshift/library-go/pkg/operator/condition/condition.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/condition/condition.go
@@ -30,6 +30,9 @@ const (
 	// This condition is set to False when the pods change state to running and are observed ready.
 	StaticPodsDegradedConditionType = "StaticPodsDegraded"
 
+	// StaticPodsAvailableConditionType is true when the static pod is available on at least one node.
+	StaticPodsAvailableConditionType = "StaticPodsAvailable"
+
 	// ConfigObservationDegradedConditionType is true when the operator failed to observe or process configuration change.
 	// This is not transient condition and normally a correction or manual intervention is required on the config custom resource.
 	ConfigObservationDegradedConditionType = "ConfigObservationDegraded"
@@ -54,6 +57,9 @@ const (
 	// The AllNodesAtLatestRevision reason is set when all master nodes are updated to the latest revision. It is false when some masters are pending revision.
 	// ZeroNodesActive reason is set to True when no active master nodes are observed. Is set to False when there is at least one active master node.
 	NodeInstallerDegradedConditionType = "NodeInstallerDegraded"
+
+	// NodeInstallerProgressingConditionType is true when the operator is moving nodes to a new revision.
+	NodeInstallerProgressingConditionType = "NodeInstallerProgressing"
 
 	// RevisionControllerDegradedConditionType is true when the operator is not able to create new desired revision because an error occurred when
 	// the operator attempted to created required resource(s) (secrets, configmaps, ...).

--- a/vendor/github.com/openshift/library-go/pkg/operator/loglevel/logging_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/loglevel/logging_controller.go
@@ -2,53 +2,27 @@ package loglevel
 
 import (
 	"context"
-	"fmt"
-	"time"
-
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/util/workqueue"
-	"k8s.io/klog"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 
+	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/events"
 	operatorv1helpers "github.com/openshift/library-go/pkg/operator/v1helpers"
 )
 
-var workQueueKey = "instance"
-
 type LogLevelController struct {
 	operatorClient operatorv1helpers.OperatorClient
-
-	cachesToSync  []cache.InformerSynced
-	queue         workqueue.RateLimitingInterface
-	eventRecorder events.Recorder
 }
 
 // sets the klog level based on desired state
-func NewClusterOperatorLoggingController(
-	operatorClient operatorv1helpers.OperatorClient,
-	recorder events.Recorder,
-) *LogLevelController {
-	c := &LogLevelController{
-		operatorClient: operatorClient,
-		eventRecorder:  recorder.WithComponentSuffix("loglevel-controller"),
-
-		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "LoggingSyncer"),
-	}
-
-	operatorClient.Informer().AddEventHandler(c.eventHandler())
-
-	c.cachesToSync = append(c.cachesToSync, operatorClient.Informer().HasSynced)
-
-	return c
+func NewClusterOperatorLoggingController(operatorClient operatorv1helpers.OperatorClient, recorder events.Recorder) factory.Controller {
+	c := &LogLevelController{operatorClient: operatorClient}
+	return factory.New().WithInformers(operatorClient.Informer()).WithSync(c.sync).ToController("LoggingSyncer", recorder)
 }
 
 // sync reacts to a change in prereqs by finding information that is required to match another value in the cluster. This
 // must be information that is logically "owned" by another component.
-func (c LogLevelController) sync() error {
+func (c LogLevelController) sync(ctx context.Context, syncCtx factory.SyncContext) error {
 	detailedSpec, _, _, err := c.operatorClient.GetOperatorState()
 	if err != nil {
 		return err
@@ -68,59 +42,10 @@ func (c LogLevelController) sync() error {
 
 	// Set the new loglevel if the operator spec changed
 	if err := SetVerbosityValue(desiredLogLevel); err != nil {
-		c.eventRecorder.Warningf("OperatorLoglevelChangeFailed", "Unable to change operator log level from %q to %q: %v", currentLogLevel, desiredLogLevel, err)
+		syncCtx.Recorder().Warningf("OperatorLoglevelChangeFailed", "Unable to change operator log level from %q to %q: %v", currentLogLevel, desiredLogLevel, err)
 		return err
 	}
 
-	c.eventRecorder.Eventf("OperatorLoglevelChange", "Operator log level changed from %q to %q", currentLogLevel, desiredLogLevel)
+	syncCtx.Recorder().Eventf("OperatorLoglevelChange", "Operator log level changed from %q to %q", currentLogLevel, desiredLogLevel)
 	return nil
-}
-
-func (c *LogLevelController) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
-	defer c.queue.ShutDown()
-
-	klog.Infof("Starting LogLevelController")
-	defer klog.Infof("Shutting down LogLevelController")
-	if !cache.WaitForCacheSync(ctx.Done(), c.cachesToSync...) {
-		return
-	}
-
-	// doesn't matter what workers say, only start one.
-	go wait.UntilWithContext(ctx, c.runWorker, time.Second)
-
-	<-ctx.Done()
-}
-
-func (c *LogLevelController) runWorker(ctx context.Context) {
-	for c.processNextWorkItem() {
-	}
-}
-
-func (c *LogLevelController) processNextWorkItem() bool {
-	dsKey, quit := c.queue.Get()
-	if quit {
-		return false
-	}
-	defer c.queue.Done(dsKey)
-
-	err := c.sync()
-	if err == nil {
-		c.queue.Forget(dsKey)
-		return true
-	}
-
-	utilruntime.HandleError(fmt.Errorf("%v failed with : %v", dsKey, err))
-	c.queue.AddRateLimited(dsKey)
-
-	return true
-}
-
-// eventHandler queues the operator to check spec and loglevel
-func (c *LogLevelController) eventHandler() cache.ResourceEventHandler {
-	return cache.ResourceEventHandlerFuncs{
-		AddFunc:    func(obj interface{}) { c.queue.Add(workQueueKey) },
-		UpdateFunc: func(old, new interface{}) { c.queue.Add(workQueueKey) },
-		DeleteFunc: func(obj interface{}) { c.queue.Add(workQueueKey) },
-	}
 }

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/monitoring/monitoring_resource_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/monitoring/monitoring_resource_controller.go
@@ -4,47 +4,39 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
-	"time"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	rbaclisterv1 "k8s.io/client-go/listers/rbac/v1"
+	"k8s.io/klog"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
+
 	"github.com/openshift/library-go/pkg/assets"
+	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/condition"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/management"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
 	"github.com/openshift/library-go/pkg/operator/staticpod/controller/monitoring/bindata"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
-	"k8s.io/apimachinery/pkg/api/errors"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/dynamic"
-	"k8s.io/client-go/informers"
-	"k8s.io/client-go/kubernetes"
-	rbaclisterv1 "k8s.io/client-go/listers/rbac/v1"
-	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/util/workqueue"
-	"k8s.io/klog"
 )
 
 const (
-	controllerWorkQueueKey = "key"
-	manifestDir            = "pkg/operator/staticpod/controller/monitoring"
+	manifestDir = "pkg/operator/staticpod/controller/monitoring"
 )
 
 var syntheticRequeueError = fmt.Errorf("synthetic requeue request")
 
 type MonitoringResourceController struct {
-	targetNamespace    string
-	serviceMonitorName string
-
+	targetNamespace          string
+	serviceMonitorName       string
 	clusterRoleBindingLister rbaclisterv1.ClusterRoleBindingLister
 	kubeClient               kubernetes.Interface
 	dynamicClient            dynamic.Interface
 	operatorClient           v1helpers.StaticPodOperatorClient
-
-	cachesToSync  []cache.InformerSynced
-	queue         workqueue.RateLimitingInterface
-	eventRecorder events.Recorder
 }
 
 // NewMonitoringResourceController creates a new backing resource controller.
@@ -56,32 +48,16 @@ func NewMonitoringResourceController(
 	kubeClient kubernetes.Interface,
 	dynamicClient dynamic.Interface,
 	eventRecorder events.Recorder,
-) *MonitoringResourceController {
+) factory.Controller {
 	c := &MonitoringResourceController{
-		targetNamespace:    targetNamespace,
-		operatorClient:     operatorClient,
-		eventRecorder:      eventRecorder.WithComponentSuffix("monitoring-resource-controller"),
-		serviceMonitorName: serviceMonitorName,
-
+		targetNamespace:          targetNamespace,
+		operatorClient:           operatorClient,
+		serviceMonitorName:       serviceMonitorName,
 		clusterRoleBindingLister: kubeInformersForTargetNamespace.Rbac().V1().ClusterRoleBindings().Lister(),
-		cachesToSync: []cache.InformerSynced{
-			kubeInformersForTargetNamespace.Core().V1().ServiceAccounts().Informer().HasSynced,
-			operatorClient.Informer().HasSynced,
-		},
-
-		queue:         workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "MonitoringResourceController"),
-		kubeClient:    kubeClient,
-		dynamicClient: dynamicClient,
+		kubeClient:               kubeClient,
+		dynamicClient:            dynamicClient,
 	}
-
-	operatorClient.Informer().AddEventHandler(c.eventHandler())
-	// TODO: We need a dynamic informer here to observe changes to ServiceMonitor resource.
-	kubeInformersForTargetNamespace.Rbac().V1().ClusterRoleBindings().Informer().AddEventHandler(c.eventHandler())
-
-	c.cachesToSync = append(c.cachesToSync, operatorClient.Informer().HasSynced)
-	c.cachesToSync = append(c.cachesToSync, kubeInformersForTargetNamespace.Rbac().V1().ClusterRoleBindings().Informer().HasSynced)
-
-	return c
+	return factory.New().WithInformers(operatorClient.Informer(), kubeInformersForTargetNamespace.Rbac().V1().ClusterRoleBindings().Informer()).WithSync(c.sync).ToController("MonitoringResourceController", eventRecorder)
 }
 
 func (c MonitoringResourceController) mustTemplateAsset(name string) ([]byte, error) {
@@ -93,7 +69,7 @@ func (c MonitoringResourceController) mustTemplateAsset(name string) ([]byte, er
 	return assets.MustCreateAssetFromTemplate(name, bindata.MustAsset(filepath.Join(manifestDir, name)), config).Data, nil
 }
 
-func (c MonitoringResourceController) sync() error {
+func (c MonitoringResourceController) sync(ctx context.Context, syncCtx factory.SyncContext) error {
 	operatorSpec, _, _, err := c.operatorClient.GetStaticPodOperatorState()
 	if err != nil {
 		return err
@@ -103,7 +79,7 @@ func (c MonitoringResourceController) sync() error {
 		return nil
 	}
 
-	directResourceResults := resourceapply.ApplyDirectly(resourceapply.NewKubeClientHolder(c.kubeClient), c.eventRecorder, c.mustTemplateAsset,
+	directResourceResults := resourceapply.ApplyDirectly(resourceapply.NewKubeClientHolder(c.kubeClient), syncCtx.Recorder(), c.mustTemplateAsset,
 		"manifests/prometheus-role.yaml",
 		"manifests/prometheus-role-binding.yaml",
 	)
@@ -119,7 +95,7 @@ func (c MonitoringResourceController) sync() error {
 	if err != nil {
 		errs = append(errs, fmt.Errorf("manifests/service-monitor.yaml: %v", err))
 	} else {
-		_, serviceMonitorErr := resourceapply.ApplyServiceMonitor(c.dynamicClient, c.eventRecorder, serviceMonitorBytes)
+		_, serviceMonitorErr := resourceapply.ApplyServiceMonitor(c.dynamicClient, syncCtx.Recorder(), serviceMonitorBytes)
 		// This is to handle 'the server could not find the requested resource' which occurs when the CRD is not available
 		// yet (the CRD is provided by prometheus operator). This produce noise and plenty of events.
 		if errors.IsNotFound(serviceMonitorErr) {
@@ -151,56 +127,4 @@ func (c MonitoringResourceController) sync() error {
 	}
 
 	return err
-}
-
-func (c *MonitoringResourceController) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
-	defer c.queue.ShutDown()
-
-	klog.Infof("Starting MonitoringResourceController")
-	defer klog.Infof("Shutting down MonitoringResourceController")
-	if !cache.WaitForCacheSync(ctx.Done(), c.cachesToSync...) {
-		return
-	}
-
-	// doesn't matter what workers say, only start one.
-	go wait.UntilWithContext(ctx, c.runWorker, time.Second)
-
-	<-ctx.Done()
-}
-
-func (c *MonitoringResourceController) runWorker(ctx context.Context) {
-	for c.processNextWorkItem() {
-	}
-}
-
-func (c *MonitoringResourceController) processNextWorkItem() bool {
-	dsKey, quit := c.queue.Get()
-	if quit {
-		return false
-	}
-	defer c.queue.Done(dsKey)
-
-	err := c.sync()
-	if err == nil {
-		c.queue.Forget(dsKey)
-		return true
-	}
-
-	if err != syntheticRequeueError {
-		utilruntime.HandleError(fmt.Errorf("%v failed with : %v", dsKey, err))
-	}
-
-	c.queue.AddRateLimited(dsKey)
-
-	return true
-}
-
-// eventHandler queues the operator to check spec and status
-func (c *MonitoringResourceController) eventHandler() cache.ResourceEventHandler {
-	return cache.ResourceEventHandlerFuncs{
-		AddFunc:    func(obj interface{}) { c.queue.Add(controllerWorkQueueKey) },
-		UpdateFunc: func(old, new interface{}) { c.queue.Add(controllerWorkQueueKey) },
-		DeleteFunc: func(obj interface{}) { c.queue.Add(controllerWorkQueueKey) },
-	}
 }

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controllers.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controllers.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog"
 
+	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/loglevel"
 	"github.com/openshift/library-go/pkg/operator/revisioncontroller"
@@ -26,10 +27,6 @@ import (
 	"github.com/openshift/library-go/pkg/operator/unsupportedconfigoverridescontroller"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 )
-
-type RunnableController interface {
-	Run(ctx context.Context, workers int)
-}
 
 type staticPodOperatorControllerBuilder struct {
 	// clients and related
@@ -88,7 +85,7 @@ type Builder interface {
 	WithCerts(certDir string, certConfigMaps, certSecrets []revisioncontroller.RevisionResource) Builder
 	WithInstaller(command []string) Builder
 	WithPruning(command []string, staticPodPrefix string) Builder
-	ToControllers() (RunnableController, error)
+	ToControllers() (factory.Controller, error)
 }
 
 func (b *staticPodOperatorControllerBuilder) WithEvents(eventRecorder events.Recorder) Builder {
@@ -137,7 +134,7 @@ func (b *staticPodOperatorControllerBuilder) WithPruning(command []string, stati
 	return b
 }
 
-func (b *staticPodOperatorControllerBuilder) ToControllers() (RunnableController, error) {
+func (b *staticPodOperatorControllerBuilder) ToControllers() (factory.Controller, error) {
 	controllers := &staticPodOperatorControllers{}
 
 	eventRecorder := b.eventRecorder
@@ -275,17 +272,24 @@ func (b *staticPodOperatorControllerBuilder) ToControllers() (RunnableController
 }
 
 type staticPodOperatorControllers struct {
-	controllers []RunnableController
+	controllers      []factory.Controller
+	shutdownContexts []context.Context
 }
 
-func (o *staticPodOperatorControllers) add(controller RunnableController) {
-	o.controllers = append(o.controllers, controller)
+// Sync implements the factory.Controller interface
+func (c *staticPodOperatorControllers) Sync(_ context.Context, _ factory.SyncContext) error {
+	return nil
 }
 
-func (o *staticPodOperatorControllers) Run(ctx context.Context, workers int) {
-	for i := range o.controllers {
-		go o.controllers[i].Run(ctx, workers)
+func (c *staticPodOperatorControllers) add(controller factory.Controller) {
+	c.controllers = append(c.controllers, controller)
+}
+
+func (c *staticPodOperatorControllers) Run(ctx context.Context, workers int) {
+	for i := range c.controllers {
+		go func(index int) {
+			c.controllers[index].Run(ctx, workers)
+		}(i)
 	}
-
 	<-ctx.Done()
 }

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticresourcecontroller/static_resource_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticresourcecontroller/static_resource_controller.go
@@ -6,12 +6,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/openshift/api"
-	operatorv1 "github.com/openshift/api/operator/v1"
-	"github.com/openshift/library-go/pkg/operator/events"
-	"github.com/openshift/library-go/pkg/operator/management"
-	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
-	"github.com/openshift/library-go/pkg/operator/v1helpers"
+	"k8s.io/klog"
+
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -19,12 +15,17 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/util/workqueue"
-	"k8s.io/klog"
+
+	"github.com/openshift/api"
+	operatorv1 "github.com/openshift/api/operator/v1"
+
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/management"
+	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
 )
 
 const (
@@ -49,9 +50,9 @@ type StaticResourceController struct {
 	operatorClient v1helpers.OperatorClient
 	clients        *resourceapply.ClientHolder
 
-	cachesToSync  []cache.InformerSynced
-	queue         workqueue.RateLimitingInterface
 	eventRecorder events.Recorder
+
+	factory *factory.Factory
 }
 
 // NewStaticResourceController returns a controller that maintains certain static manifests. Most "normal" types are supported,
@@ -73,10 +74,9 @@ func NewStaticResourceController(
 		clients:        clients,
 
 		eventRecorder: eventRecorder.WithComponentSuffix(strings.ToLower(name)),
-		queue:         workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), name),
-	}
 
-	c.operatorClient.Informer().AddEventHandler(c.eventHandler())
+		factory: factory.New().WithInformers(operatorClient.Informer()).ResyncEvery(1 * time.Minute),
+	}
 
 	return c
 }
@@ -105,14 +105,14 @@ func (c *StaticResourceController) AddKubeInformers(kubeInformersByNamespace v1h
 
 		// find the right subset of informers.  Interestingly, cluster scoped resources require cluster scoped informers
 		var informer informers.SharedInformerFactory
-		if _, ok := requiredObj.(*corev1.Namespace); !ok {
-			informer := kubeInformersByNamespace.InformersFor(metadata.GetName())
+		if _, ok := requiredObj.(*corev1.Namespace); ok {
+			informer = kubeInformersByNamespace.InformersFor(metadata.GetName())
 			if informer == nil {
 				utilruntime.HandleError(fmt.Errorf("missing informer for namespace %q; no dynamic wiring added, time-based only.", metadata.GetName()))
 				continue
 			}
 		} else {
-			informer := kubeInformersByNamespace.InformersFor(metadata.GetNamespace())
+			informer = kubeInformersByNamespace.InformersFor(metadata.GetNamespace())
 			if informer == nil {
 				utilruntime.HandleError(fmt.Errorf("missing informer for namespace %q; no dynamic wiring added, time-based only.", metadata.GetNamespace()))
 				continue
@@ -152,57 +152,16 @@ func (c *StaticResourceController) AddKubeInformers(kubeInformersByNamespace v1h
 }
 
 func (c *StaticResourceController) AddInformer(informer cache.SharedIndexInformer) *StaticResourceController {
-	informer.AddEventHandler(c.eventHandler())
-	c.cachesToSync = append(c.cachesToSync, informer.HasSynced)
+	c.factory.WithInformers(informer)
 	return c
 }
 
 func (c *StaticResourceController) AddNamespaceInformer(informer cache.SharedIndexInformer, namespaces ...string) *StaticResourceController {
-	interestingNamespaces := sets.NewString(namespaces...)
-	informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
-			ns, ok := obj.(*corev1.Namespace)
-			if !ok {
-				c.queue.Add(workQueueKey)
-			}
-			if interestingNamespaces.Has(ns.Name) {
-				c.queue.Add(workQueueKey)
-			}
-		},
-		UpdateFunc: func(old, new interface{}) {
-			ns, ok := old.(*corev1.Namespace)
-			if !ok {
-				c.queue.Add(workQueueKey)
-			}
-			if interestingNamespaces.Has(ns.Name) {
-				c.queue.Add(workQueueKey)
-			}
-		},
-		DeleteFunc: func(obj interface{}) {
-			ns, ok := obj.(*corev1.Namespace)
-			if !ok {
-				tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
-				if !ok {
-					utilruntime.HandleError(fmt.Errorf("couldn't get object from tombstone %#v", obj))
-					return
-				}
-				ns, ok = tombstone.Obj.(*corev1.Namespace)
-				if !ok {
-					utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a Namespace %#v", obj))
-					return
-				}
-			}
-			if interestingNamespaces.Has(ns.Name) {
-				c.queue.Add(workQueueKey)
-			}
-		},
-	})
-	c.cachesToSync = append(c.cachesToSync, informer.HasSynced)
-
+	c.factory.WithNamespaceInformer(informer, namespaces...)
 	return c
 }
 
-func (c StaticResourceController) Sync() error {
+func (c StaticResourceController) Sync(ctx context.Context, syncContext factory.SyncContext) error {
 	operatorSpec, _, _, err := c.operatorClient.GetOperatorState()
 	if err != nil {
 		return err
@@ -212,7 +171,7 @@ func (c StaticResourceController) Sync() error {
 	}
 
 	errors := []error{}
-	directResourceResults := resourceapply.ApplyDirectly(c.clients, c.eventRecorder, c.manifests, c.files...)
+	directResourceResults := resourceapply.ApplyDirectly(c.clients, syncContext.Recorder(), c.manifests, c.files...)
 	for _, currResult := range directResourceResults {
 		if currResult.Error != nil {
 			errors = append(errors, fmt.Errorf("%q (%T): %v", currResult.File, currResult.Type, currResult.Error))
@@ -254,57 +213,5 @@ func appendErrors(_ *operatorv1.OperatorStatus, _ bool, err error) []error {
 }
 
 func (c *StaticResourceController) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
-	defer c.queue.ShutDown()
-
-	klog.Infof("Starting %s", c.name)
-	defer klog.Infof("Shutting down %s", c.name)
-
-	if !cache.WaitForCacheSync(ctx.Done(), c.cachesToSync...) {
-		return
-	}
-
-	// doesn't matter what workers say, only start one.
-	go wait.Until(c.runWorker, time.Second, ctx.Done())
-
-	// add time based trigger
-	go wait.PollImmediateUntil(time.Minute, func() (bool, error) {
-		c.queue.Add(workQueueKey)
-		return false, nil
-	}, ctx.Done())
-
-	<-ctx.Done()
-}
-
-func (c *StaticResourceController) runWorker() {
-	for c.processNextWorkItem() {
-	}
-}
-
-func (c *StaticResourceController) processNextWorkItem() bool {
-	dsKey, quit := c.queue.Get()
-	if quit {
-		return false
-	}
-	defer c.queue.Done(dsKey)
-
-	err := c.Sync()
-	if err == nil {
-		c.queue.Forget(dsKey)
-		return true
-	}
-
-	utilruntime.HandleError(fmt.Errorf("%v failed with : %v", dsKey, err))
-	c.queue.AddRateLimited(dsKey)
-
-	return true
-}
-
-// eventHandler queues the operator to check spec and status
-func (c *StaticResourceController) eventHandler() cache.ResourceEventHandler {
-	return cache.ResourceEventHandlerFuncs{
-		AddFunc:    func(obj interface{}) { c.queue.Add(workQueueKey) },
-		UpdateFunc: func(old, new interface{}) { c.queue.Add(workQueueKey) },
-		DeleteFunc: func(obj interface{}) { c.queue.Add(workQueueKey) },
-	}
+	c.factory.WithSync(c.Sync).ToController("", c.eventRecorder).Run(ctx, workers)
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -152,7 +152,7 @@ github.com/openshift/client-go/operator/clientset/versioned/typed/operator/v1alp
 github.com/openshift/client-go/route/clientset/versioned
 github.com/openshift/client-go/route/clientset/versioned/scheme
 github.com/openshift/client-go/route/clientset/versioned/typed/route/v1
-# github.com/openshift/library-go v0.0.0-20200127211524-05e7d57f0ed3
+# github.com/openshift/library-go v0.0.0-20200205212311-6f4b8eee2d65
 github.com/openshift/library-go/alpha-build-machinery
 github.com/openshift/library-go/alpha-build-machinery/make
 github.com/openshift/library-go/alpha-build-machinery/make/lib
@@ -168,6 +168,7 @@ github.com/openshift/library-go/pkg/config/configdefaults
 github.com/openshift/library-go/pkg/config/leaderelection
 github.com/openshift/library-go/pkg/config/serving
 github.com/openshift/library-go/pkg/controller/controllercmd
+github.com/openshift/library-go/pkg/controller/factory
 github.com/openshift/library-go/pkg/controller/fileobserver
 github.com/openshift/library-go/pkg/controller/metrics
 github.com/openshift/library-go/pkg/crypto


### PR DESCRIPTION
Update to fix the operator. This cannot be done in the static pod code itself because some consumers like etcd still rely on those directly set conditions and removing them would break it.