### PR TITLE
Bug 1810008: Add cert syncer

### DIFF
--- a/bindata/v4.1.0/kube-scheduler/kubeconfig-cert-syncer.yaml
+++ b/bindata/v4.1.0/kube-scheduler/kubeconfig-cert-syncer.yaml
@@ -1,15 +1,16 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: scheduler-kubeconfig
+  name: kube-scheduler-cert-syncer-kubeconfig
   namespace: openshift-kube-scheduler
 data:
   kubeconfig: |
     apiVersion: v1
     clusters:
       - cluster:
-          certificate-authority: /etc/kubernetes/static-pod-resources/configmaps/serviceaccount-ca/ca-bundle.crt
+          certificate-authority: /etc/kubernetes/static-pod-resources/secrets/localhost-recovery-client-token/ca.crt
           server: https://localhost:6443
+          tls-server-name: localhost-recovery
         name: loopback
     contexts:
       - context:
@@ -22,5 +23,4 @@ data:
     users:
       - name: kube-scheduler
         user:
-          client-certificate: /etc/kubernetes/static-pod-certs/secrets/kube-scheduler-client-cert-key/tls.crt
-          client-key: /etc/kubernetes/static-pod-certs/secrets/kube-scheduler-client-cert-key/tls.key
+          tokenFile: /etc/kubernetes/static-pod-resources/secrets/localhost-recovery-client-token/token

--- a/bindata/v4.1.0/kube-scheduler/localhost-recovery-client-crb.yaml
+++ b/bindata/v4.1.0/kube-scheduler/localhost-recovery-client-crb.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:openshift:operator:kube-scheduler-recovery
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: localhost-recovery-client
+  namespace: openshift-kube-scheduler

--- a/bindata/v4.1.0/kube-scheduler/localhost-recovery-sa.yaml
+++ b/bindata/v4.1.0/kube-scheduler/localhost-recovery-sa.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: localhost-recovery-client
+  namespace: openshift-kube-scheduler

--- a/bindata/v4.1.0/kube-scheduler/localhost-recovery-token.yaml
+++ b/bindata/v4.1.0/kube-scheduler/localhost-recovery-token.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: localhost-recovery-client-token
+  namespace: openshift-kube-scheduler
+  annotations:
+    kubernetes.io/service-account.name: localhost-recovery-client
+type: kubernetes.io/service-account-token

--- a/bindata/v4.1.0/kube-scheduler/pod.yaml
+++ b/bindata/v4.1.0/kube-scheduler/pod.yaml
@@ -22,7 +22,7 @@ spec:
         sleep 1
       done
   containers:
-  - name: scheduler
+  - name: kube-scheduler
     image: ${IMAGE}
     imagePullPolicy: IfNotPresent
     terminationMessagePolicy: FallbackToLogsOnError
@@ -41,6 +41,8 @@ spec:
     volumeMounts:
     - mountPath: /etc/kubernetes/static-pod-resources
       name: resource-dir
+    - mountPath: /etc/kubernetes/static-pod-certs
+      name: cert-dir
     livenessProbe:
       httpGet:
         scheme: HTTP
@@ -55,6 +57,33 @@ spec:
         path: healthz
       initialDelaySeconds: 45
       timeOutSeconds: 10
+  - name: kube-scheduler-cert-syncer
+    env:
+    - name: POD_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.name
+    - name: POD_NAMESPACE
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
+    image: ${OPERATOR_IMAGE}
+    imagePullPolicy: IfNotPresent
+    terminationMessagePolicy: FallbackToLogsOnError
+    command: ["cluster-kube-scheduler-operator", "cert-syncer"]
+    args:
+      - --kubeconfig=/etc/kubernetes/static-pod-resources/configmaps/kube-scheduler-cert-syncer-kubeconfig/kubeconfig
+      - --namespace=$(POD_NAMESPACE)
+      - --destination-dir=/etc/kubernetes/static-pod-certs
+    resources:
+      requests:
+        memory: 50Mi
+        cpu: 10m
+    volumeMounts:
+      - mountPath: /etc/kubernetes/static-pod-resources
+        name: resource-dir
+      - mountPath: /etc/kubernetes/static-pod-certs
+        name: cert-dir
   hostNetwork: true
   priorityClassName: system-node-critical
   tolerations:
@@ -63,3 +92,6 @@ spec:
   - hostPath:
       path: /etc/kubernetes/static-pod-resources/kube-scheduler-pod-REVISION
     name: resource-dir
+  - hostPath:
+      path: /etc/kubernetes/static-pod-resources/kube-scheduler-certs
+    name: cert-dir

--- a/cmd/cluster-kube-scheduler-operator/main.go
+++ b/cmd/cluster-kube-scheduler-operator/main.go
@@ -14,7 +14,9 @@ import (
 	"k8s.io/component-base/logs"
 
 	"github.com/openshift/cluster-kube-scheduler-operator/cmd/render"
-	"github.com/openshift/cluster-kube-scheduler-operator/pkg/cmd/operator"
+	operatorcmd "github.com/openshift/cluster-kube-scheduler-operator/pkg/cmd/operator"
+	"github.com/openshift/cluster-kube-scheduler-operator/pkg/operator"
+	"github.com/openshift/library-go/pkg/operator/staticpod/certsyncpod"
 	"github.com/openshift/library-go/pkg/operator/staticpod/installerpod"
 	"github.com/openshift/library-go/pkg/operator/staticpod/prune"
 )
@@ -45,10 +47,11 @@ func NewSchedulerOperatorCommand() *cobra.Command {
 		},
 	}
 
-	cmd.AddCommand(operator.NewOperator())
+	cmd.AddCommand(operatorcmd.NewOperator())
 	cmd.AddCommand(render.NewRenderCommand())
 	cmd.AddCommand(installerpod.NewInstaller())
 	cmd.AddCommand(prune.NewPrune())
+	cmd.AddCommand(certsyncpod.NewCertSyncControllerCommand(operator.CertConfigMaps, operator.CertSecrets))
 
 	return cmd
 }

--- a/pkg/operator/target_config_reconciler.go
+++ b/pkg/operator/target_config_reconciler.go
@@ -24,20 +24,21 @@ import (
 )
 
 type TargetConfigReconciler struct {
-	targetImagePullSpec  string
-	operatorClient       v1helpers.StaticPodOperatorClient
-	kubeClient           kubernetes.Interface
-	eventRecorder        events.Recorder
-	configMapLister      corev1listers.ConfigMapLister
-	featureGateLister    configlistersv1.FeatureGateLister
-	featureGateCacheSync cache.InformerSynced
+	targetImagePullSpec   string
+	operatorImagePullSpec string
+	operatorClient        v1helpers.StaticPodOperatorClient
+	kubeClient            kubernetes.Interface
+	eventRecorder         events.Recorder
+	configMapLister       corev1listers.ConfigMapLister
+	featureGateLister     configlistersv1.FeatureGateLister
+	featureGateCacheSync  cache.InformerSynced
 	// queue only ever has one item, but it has nice error handling backoff/retry semantics
 	queue workqueue.RateLimitingInterface
 }
 
 func NewTargetConfigReconciler(
+	targetImagePullSpec, operatorImagePullSpec string,
 	operatorConfigClient v1helpers.OperatorClient,
-	targetImagePullSpec string,
 	namespacedKubeInformers informers.SharedInformerFactory,
 	kubeInformersForNamespaces v1helpers.KubeInformersForNamespaces,
 	configInformer configinformers.SharedInformerFactory,
@@ -46,11 +47,12 @@ func NewTargetConfigReconciler(
 	eventRecorder events.Recorder,
 ) *TargetConfigReconciler {
 	c := &TargetConfigReconciler{
-		targetImagePullSpec: targetImagePullSpec,
-		kubeClient:          kubeClient,
-		configMapLister:     kubeInformersForNamespaces.ConfigMapLister(),
-		operatorClient:      operatorClient,
-		eventRecorder:       eventRecorder,
+		targetImagePullSpec:   targetImagePullSpec,
+		operatorImagePullSpec: operatorImagePullSpec,
+		kubeClient:            kubeClient,
+		configMapLister:       kubeInformersForNamespaces.ConfigMapLister(),
+		operatorClient:        operatorClient,
+		eventRecorder:         eventRecorder,
 
 		featureGateLister:    configInformer.Config().V1().FeatureGates().Lister(),
 		featureGateCacheSync: configInformer.Config().V1().FeatureGates().Informer().HasSynced,

--- a/pkg/operator/target_config_reconciler_v410_00.go
+++ b/pkg/operator/target_config_reconciler_v410_00.go
@@ -11,7 +11,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	coreclientv1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/klog"
 
@@ -36,12 +36,16 @@ func createTargetConfigReconciler_v311_00_to_latest(c TargetConfigReconciler, re
 	directResourceResults := resourceapply.ApplyDirectly(resourceapply.NewKubeClientHolder(c.kubeClient), c.eventRecorder, v410_00_assets.Asset,
 		"v4.1.0/kube-scheduler/ns.yaml",
 		"v4.1.0/kube-scheduler/kubeconfig-cm.yaml",
+		"v4.1.0/kube-scheduler/kubeconfig-cert-syncer.yaml",
 		"v4.1.0/kube-scheduler/leader-election-rolebinding.yaml",
 		"v4.1.0/kube-scheduler/scheduler-clusterrolebinding.yaml",
 		"v4.1.0/kube-scheduler/policyconfigmap-role.yaml",
 		"v4.1.0/kube-scheduler/policyconfigmap-rolebinding.yaml",
 		"v4.1.0/kube-scheduler/svc.yaml",
 		"v4.1.0/kube-scheduler/sa.yaml",
+		"v4.1.0/kube-scheduler/localhost-recovery-client-crb.yaml",
+		"v4.1.0/kube-scheduler/localhost-recovery-sa.yaml",
+		"v4.1.0/kube-scheduler/localhost-recovery-token.yaml",
 	)
 	for _, currResult := range directResourceResults {
 		if currResult.Error != nil {
@@ -56,7 +60,11 @@ func createTargetConfigReconciler_v311_00_to_latest(c TargetConfigReconciler, re
 	if err != nil {
 		errors = append(errors, fmt.Errorf("%q: %v", "configmap/serviceaccount-ca", err))
 	}
-	_, _, err = managePod_v311_00_to_latest(c.kubeClient.CoreV1(), c.kubeClient.CoreV1(), recorder, operatorSpec, c.targetImagePullSpec, c.featureGateLister)
+	err = ensureLocalhostRecoverySAToken(c.kubeClient.CoreV1(), recorder)
+	if err != nil {
+		errors = append(errors, fmt.Errorf("%q: %v", "serviceaccount/localhost-recovery-client", err))
+	}
+	_, _, err = managePod_v311_00_to_latest(c.kubeClient.CoreV1(), c.kubeClient.CoreV1(), recorder, operatorSpec, c.targetImagePullSpec, c.operatorImagePullSpec, c.featureGateLister)
 	if err != nil {
 		errors = append(errors, fmt.Errorf("%q: %v", "configmap/kube-scheduler-pod", err))
 	}
@@ -85,7 +93,7 @@ func createTargetConfigReconciler_v311_00_to_latest(c TargetConfigReconciler, re
 	return false, nil
 }
 
-func manageKubeSchedulerConfigMap_v311_00_to_latest(lister corev1listers.ConfigMapLister, client coreclientv1.ConfigMapsGetter, recorder events.Recorder, operatorSpec *operatorv1.StaticPodOperatorSpec) (*corev1.ConfigMap, bool, error) {
+func manageKubeSchedulerConfigMap_v311_00_to_latest(lister corev1listers.ConfigMapLister, client corev1client.ConfigMapsGetter, recorder events.Recorder, operatorSpec *operatorv1.StaticPodOperatorSpec) (*corev1.ConfigMap, bool, error) {
 	configMap := resourceread.ReadConfigMapV1OrDie(v410_00_assets.MustAsset("v4.1.0/kube-scheduler/cm.yaml"))
 	defaultConfig := v410_00_assets.MustAsset("v4.1.0/config/defaultconfig-postbootstrap.yaml")
 	requiredConfigMap, _, err := resourcemerge.MergeConfigMap(configMap, "config.yaml", nil, defaultConfig, operatorSpec.ObservedConfig.Raw, operatorSpec.UnsupportedConfigOverrides.Raw)
@@ -95,12 +103,26 @@ func manageKubeSchedulerConfigMap_v311_00_to_latest(lister corev1listers.ConfigM
 	return resourceapply.ApplyConfigMap(client, recorder, requiredConfigMap)
 }
 
-func managePod_v311_00_to_latest(configMapsGetter coreclientv1.ConfigMapsGetter, secretsGetter coreclientv1.SecretsGetter, recorder events.Recorder, operatorSpec *operatorv1.StaticPodOperatorSpec, imagePullSpec string, featureGateLister configlistersv1.FeatureGateLister) (*corev1.ConfigMap, bool, error) {
+func managePod_v311_00_to_latest(configMapsGetter corev1client.ConfigMapsGetter, secretsGetter corev1client.SecretsGetter, recorder events.Recorder, operatorSpec *operatorv1.StaticPodOperatorSpec, imagePullSpec, operatorImagePullSpec string, featureGateLister configlistersv1.FeatureGateLister) (*corev1.ConfigMap, bool, error) {
 	required := resourceread.ReadPodV1OrDie(v410_00_assets.MustAsset("v4.1.0/kube-scheduler/pod.yaml"))
-	if len(imagePullSpec) > 0 {
-		required.Spec.Containers[0].Image = imagePullSpec
-		if len(required.Spec.InitContainers) > 0 {
-			required.Spec.InitContainers[0].Image = imagePullSpec
+	images := map[string]string{
+		"${IMAGE}":          imagePullSpec,
+		"${OPERATOR_IMAGE}": operatorImagePullSpec,
+	}
+	for i := range required.Spec.Containers {
+		for pat, img := range images {
+			if required.Spec.Containers[i].Image == pat {
+				required.Spec.Containers[i].Image = img
+				break
+			}
+		}
+	}
+	for i := range required.Spec.InitContainers {
+		for pat, img := range images {
+			if required.Spec.InitContainers[i].Image == pat {
+				required.Spec.InitContainers[i].Image = img
+				break
+			}
 		}
 	}
 
@@ -186,7 +208,7 @@ func generateFeatureGates(enabledFeatureGates, disabledFeatureGates []string, fe
 	return featureGates
 }
 
-func manageServiceAccountCABundle(lister corev1listers.ConfigMapLister, client coreclientv1.ConfigMapsGetter, recorder events.Recorder) (*corev1.ConfigMap, bool, error) {
+func manageServiceAccountCABundle(lister corev1listers.ConfigMapLister, client corev1client.ConfigMapsGetter, recorder events.Recorder) (*corev1.ConfigMap, bool, error) {
 	requiredConfigMap, err := resourcesynccontroller.CombineCABundleConfigMaps(
 		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.TargetNamespace, Name: "serviceaccount-ca"},
 		lister,
@@ -200,4 +222,53 @@ func manageServiceAccountCABundle(lister corev1listers.ConfigMapLister, client c
 		return nil, false, err
 	}
 	return resourceapply.ApplyConfigMap(client, recorder, requiredConfigMap)
+}
+
+func ensureLocalhostRecoverySAToken(client corev1client.CoreV1Interface, recorder events.Recorder) error {
+	requiredSA := resourceread.ReadServiceAccountV1OrDie(v410_00_assets.MustAsset("v4.1.0/kube-scheduler/localhost-recovery-sa.yaml"))
+	requiredToken := resourceread.ReadSecretV1OrDie(v410_00_assets.MustAsset("v4.1.0/kube-scheduler/localhost-recovery-token.yaml"))
+
+	saClient := client.ServiceAccounts(operatorclient.TargetNamespace)
+	serviceAccount, err := saClient.Get(requiredSA.Name, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	// The default token secrets get random names so we have created a custom secret
+	// to be populated with SA token so we have a stable name.
+	secretsClient := client.Secrets(operatorclient.TargetNamespace)
+	token, err := secretsClient.Get(requiredToken.Name, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	// Token creation / injection for a SA is asynchronous.
+	// We will report and error if it's missing, go degraded and get re-queued when the SA token is updated.
+
+	uid := token.Annotations[corev1.ServiceAccountUIDKey]
+	if len(uid) == 0 {
+		return fmt.Errorf("secret %s/%s hasn't been populated with SA token yet: missing SA UID", token.Namespace, token.Name)
+	}
+
+	if uid != string(serviceAccount.UID) {
+		return fmt.Errorf("secret %s/%s hasn't been populated with current SA token yet: SA UID mismatch", token.Namespace, token.Name)
+	}
+
+	if len(token.Data) == 0 {
+		return fmt.Errorf("secret %s/%s hasn't been populated with any data yet", token.Namespace, token.Name)
+	}
+
+	// Explicitly check that the fields we use are there, so we find out easily if some are removed or renamed.
+
+	_, ok := token.Data["token"]
+	if !ok {
+		return fmt.Errorf("secret %s/%s hasn't been populated with current SA token yet", token.Namespace, token.Name)
+	}
+
+	_, ok = token.Data["ca.crt"]
+	if !ok {
+		return fmt.Errorf("secret %s/%s hasn't been populated with current SA token root CA yet", token.Namespace, token.Name)
+	}
+
+	return err
 }

--- a/pkg/operator/v410_00_assets/bindata.go
+++ b/pkg/operator/v410_00_assets/bindata.go
@@ -3,8 +3,12 @@
 // bindata/v4.1.0/config/defaultconfig-postbootstrap.yaml
 // bindata/v4.1.0/config/defaultconfig.yaml
 // bindata/v4.1.0/kube-scheduler/cm.yaml
+// bindata/v4.1.0/kube-scheduler/kubeconfig-cert-syncer.yaml
 // bindata/v4.1.0/kube-scheduler/kubeconfig-cm.yaml
 // bindata/v4.1.0/kube-scheduler/leader-election-rolebinding.yaml
+// bindata/v4.1.0/kube-scheduler/localhost-recovery-client-crb.yaml
+// bindata/v4.1.0/kube-scheduler/localhost-recovery-sa.yaml
+// bindata/v4.1.0/kube-scheduler/localhost-recovery-token.yaml
 // bindata/v4.1.0/kube-scheduler/ns.yaml
 // bindata/v4.1.0/kube-scheduler/pod-cm.yaml
 // bindata/v4.1.0/kube-scheduler/pod.yaml
@@ -125,6 +129,49 @@ func v410KubeSchedulerCmYaml() (*asset, error) {
 	return a, nil
 }
 
+var _v410KubeSchedulerKubeconfigCertSyncerYaml = []byte(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kube-scheduler-cert-syncer-kubeconfig
+  namespace: openshift-kube-scheduler
+data:
+  kubeconfig: |
+    apiVersion: v1
+    clusters:
+      - cluster:
+          certificate-authority: /etc/kubernetes/static-pod-resources/secrets/localhost-recovery-client-token/ca.crt
+          server: https://localhost:6443
+          tls-server-name: localhost-recovery
+        name: loopback
+    contexts:
+      - context:
+          cluster: loopback
+          user: kube-scheduler
+        name: kube-scheduler
+    current-context: kube-scheduler
+    kind: Config
+    preferences: {}
+    users:
+      - name: kube-scheduler
+        user:
+          tokenFile: /etc/kubernetes/static-pod-resources/secrets/localhost-recovery-client-token/token
+`)
+
+func v410KubeSchedulerKubeconfigCertSyncerYamlBytes() ([]byte, error) {
+	return _v410KubeSchedulerKubeconfigCertSyncerYaml, nil
+}
+
+func v410KubeSchedulerKubeconfigCertSyncerYaml() (*asset, error) {
+	bytes, err := v410KubeSchedulerKubeconfigCertSyncerYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "v4.1.0/kube-scheduler/kubeconfig-cert-syncer.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
 var _v410KubeSchedulerKubeconfigCmYaml = []byte(`apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -149,8 +196,8 @@ data:
     users:
       - name: kube-scheduler
         user:
-          client-certificate: /etc/kubernetes/static-pod-resources/secrets/kube-scheduler-client-cert-key/tls.crt
-          client-key: /etc/kubernetes/static-pod-resources/secrets/kube-scheduler-client-cert-key/tls.key
+          client-certificate: /etc/kubernetes/static-pod-certs/secrets/kube-scheduler-client-cert-key/tls.crt
+          client-key: /etc/kubernetes/static-pod-certs/secrets/kube-scheduler-client-cert-key/tls.key
 `)
 
 func v410KubeSchedulerKubeconfigCmYamlBytes() ([]byte, error) {
@@ -192,6 +239,81 @@ func v410KubeSchedulerLeaderElectionRolebindingYaml() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "v4.1.0/kube-scheduler/leader-election-rolebinding.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _v410KubeSchedulerLocalhostRecoveryClientCrbYaml = []byte(`apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:openshift:operator:kube-scheduler-recovery
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: localhost-recovery-client
+  namespace: openshift-kube-scheduler
+`)
+
+func v410KubeSchedulerLocalhostRecoveryClientCrbYamlBytes() ([]byte, error) {
+	return _v410KubeSchedulerLocalhostRecoveryClientCrbYaml, nil
+}
+
+func v410KubeSchedulerLocalhostRecoveryClientCrbYaml() (*asset, error) {
+	bytes, err := v410KubeSchedulerLocalhostRecoveryClientCrbYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "v4.1.0/kube-scheduler/localhost-recovery-client-crb.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _v410KubeSchedulerLocalhostRecoverySaYaml = []byte(`apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: localhost-recovery-client
+  namespace: openshift-kube-scheduler
+`)
+
+func v410KubeSchedulerLocalhostRecoverySaYamlBytes() ([]byte, error) {
+	return _v410KubeSchedulerLocalhostRecoverySaYaml, nil
+}
+
+func v410KubeSchedulerLocalhostRecoverySaYaml() (*asset, error) {
+	bytes, err := v410KubeSchedulerLocalhostRecoverySaYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "v4.1.0/kube-scheduler/localhost-recovery-sa.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _v410KubeSchedulerLocalhostRecoveryTokenYaml = []byte(`apiVersion: v1
+kind: Secret
+metadata:
+  name: localhost-recovery-client-token
+  namespace: openshift-kube-scheduler
+  annotations:
+    kubernetes.io/service-account.name: localhost-recovery-client
+type: kubernetes.io/service-account-token
+`)
+
+func v410KubeSchedulerLocalhostRecoveryTokenYamlBytes() ([]byte, error) {
+	return _v410KubeSchedulerLocalhostRecoveryTokenYaml, nil
+}
+
+func v410KubeSchedulerLocalhostRecoveryTokenYaml() (*asset, error) {
+	bytes, err := v410KubeSchedulerLocalhostRecoveryTokenYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "v4.1.0/kube-scheduler/localhost-recovery-token.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -272,7 +394,7 @@ spec:
         sleep 1
       done
   containers:
-  - name: scheduler
+  - name: kube-scheduler
     image: ${IMAGE}
     imagePullPolicy: IfNotPresent
     terminationMessagePolicy: FallbackToLogsOnError
@@ -291,6 +413,8 @@ spec:
     volumeMounts:
     - mountPath: /etc/kubernetes/static-pod-resources
       name: resource-dir
+    - mountPath: /etc/kubernetes/static-pod-certs
+      name: cert-dir
     livenessProbe:
       httpGet:
         scheme: HTTP
@@ -305,6 +429,33 @@ spec:
         path: healthz
       initialDelaySeconds: 45
       timeOutSeconds: 10
+  - name: kube-scheduler-cert-syncer
+    env:
+    - name: POD_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.name
+    - name: POD_NAMESPACE
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
+    image: ${OPERATOR_IMAGE}
+    imagePullPolicy: IfNotPresent
+    terminationMessagePolicy: FallbackToLogsOnError
+    command: ["cluster-kube-scheduler-operator", "cert-syncer"]
+    args:
+      - --kubeconfig=/etc/kubernetes/static-pod-resources/configmaps/kube-scheduler-cert-syncer-kubeconfig/kubeconfig
+      - --namespace=$(POD_NAMESPACE)
+      - --destination-dir=/etc/kubernetes/static-pod-certs
+    resources:
+      requests:
+        memory: 50Mi
+        cpu: 10m
+    volumeMounts:
+      - mountPath: /etc/kubernetes/static-pod-resources
+        name: resource-dir
+      - mountPath: /etc/kubernetes/static-pod-certs
+        name: cert-dir
   hostNetwork: true
   priorityClassName: system-node-critical
   tolerations:
@@ -313,6 +464,9 @@ spec:
   - hostPath:
       path: /etc/kubernetes/static-pod-resources/kube-scheduler-pod-REVISION
     name: resource-dir
+  - hostPath:
+      path: /etc/kubernetes/static-pod-resources/kube-scheduler-certs
+    name: cert-dir
 `)
 
 func v410KubeSchedulerPodYamlBytes() ([]byte, error) {
@@ -527,19 +681,23 @@ func AssetNames() []string {
 
 // _bindata is a table, holding each asset generator, mapped to its name.
 var _bindata = map[string]func() (*asset, error){
-	"v4.1.0/config/defaultconfig-postbootstrap.yaml":          v410ConfigDefaultconfigPostbootstrapYaml,
-	"v4.1.0/config/defaultconfig.yaml":                        v410ConfigDefaultconfigYaml,
-	"v4.1.0/kube-scheduler/cm.yaml":                           v410KubeSchedulerCmYaml,
-	"v4.1.0/kube-scheduler/kubeconfig-cm.yaml":                v410KubeSchedulerKubeconfigCmYaml,
-	"v4.1.0/kube-scheduler/leader-election-rolebinding.yaml":  v410KubeSchedulerLeaderElectionRolebindingYaml,
-	"v4.1.0/kube-scheduler/ns.yaml":                           v410KubeSchedulerNsYaml,
-	"v4.1.0/kube-scheduler/pod-cm.yaml":                       v410KubeSchedulerPodCmYaml,
-	"v4.1.0/kube-scheduler/pod.yaml":                          v410KubeSchedulerPodYaml,
-	"v4.1.0/kube-scheduler/policyconfigmap-role.yaml":         v410KubeSchedulerPolicyconfigmapRoleYaml,
-	"v4.1.0/kube-scheduler/policyconfigmap-rolebinding.yaml":  v410KubeSchedulerPolicyconfigmapRolebindingYaml,
-	"v4.1.0/kube-scheduler/sa.yaml":                           v410KubeSchedulerSaYaml,
-	"v4.1.0/kube-scheduler/scheduler-clusterrolebinding.yaml": v410KubeSchedulerSchedulerClusterrolebindingYaml,
-	"v4.1.0/kube-scheduler/svc.yaml":                          v410KubeSchedulerSvcYaml,
+	"v4.1.0/config/defaultconfig-postbootstrap.yaml":           v410ConfigDefaultconfigPostbootstrapYaml,
+	"v4.1.0/config/defaultconfig.yaml":                         v410ConfigDefaultconfigYaml,
+	"v4.1.0/kube-scheduler/cm.yaml":                            v410KubeSchedulerCmYaml,
+	"v4.1.0/kube-scheduler/kubeconfig-cert-syncer.yaml":        v410KubeSchedulerKubeconfigCertSyncerYaml,
+	"v4.1.0/kube-scheduler/kubeconfig-cm.yaml":                 v410KubeSchedulerKubeconfigCmYaml,
+	"v4.1.0/kube-scheduler/leader-election-rolebinding.yaml":   v410KubeSchedulerLeaderElectionRolebindingYaml,
+	"v4.1.0/kube-scheduler/localhost-recovery-client-crb.yaml": v410KubeSchedulerLocalhostRecoveryClientCrbYaml,
+	"v4.1.0/kube-scheduler/localhost-recovery-sa.yaml":         v410KubeSchedulerLocalhostRecoverySaYaml,
+	"v4.1.0/kube-scheduler/localhost-recovery-token.yaml":      v410KubeSchedulerLocalhostRecoveryTokenYaml,
+	"v4.1.0/kube-scheduler/ns.yaml":                            v410KubeSchedulerNsYaml,
+	"v4.1.0/kube-scheduler/pod-cm.yaml":                        v410KubeSchedulerPodCmYaml,
+	"v4.1.0/kube-scheduler/pod.yaml":                           v410KubeSchedulerPodYaml,
+	"v4.1.0/kube-scheduler/policyconfigmap-role.yaml":          v410KubeSchedulerPolicyconfigmapRoleYaml,
+	"v4.1.0/kube-scheduler/policyconfigmap-rolebinding.yaml":   v410KubeSchedulerPolicyconfigmapRolebindingYaml,
+	"v4.1.0/kube-scheduler/sa.yaml":                            v410KubeSchedulerSaYaml,
+	"v4.1.0/kube-scheduler/scheduler-clusterrolebinding.yaml":  v410KubeSchedulerSchedulerClusterrolebindingYaml,
+	"v4.1.0/kube-scheduler/svc.yaml":                           v410KubeSchedulerSvcYaml,
 }
 
 // AssetDir returns the file names below a certain
@@ -589,17 +747,21 @@ var _bintree = &bintree{nil, map[string]*bintree{
 			"defaultconfig.yaml":               {v410ConfigDefaultconfigYaml, map[string]*bintree{}},
 		}},
 		"kube-scheduler": {nil, map[string]*bintree{
-			"cm.yaml":                           {v410KubeSchedulerCmYaml, map[string]*bintree{}},
-			"kubeconfig-cm.yaml":                {v410KubeSchedulerKubeconfigCmYaml, map[string]*bintree{}},
-			"leader-election-rolebinding.yaml":  {v410KubeSchedulerLeaderElectionRolebindingYaml, map[string]*bintree{}},
-			"ns.yaml":                           {v410KubeSchedulerNsYaml, map[string]*bintree{}},
-			"pod-cm.yaml":                       {v410KubeSchedulerPodCmYaml, map[string]*bintree{}},
-			"pod.yaml":                          {v410KubeSchedulerPodYaml, map[string]*bintree{}},
-			"policyconfigmap-role.yaml":         {v410KubeSchedulerPolicyconfigmapRoleYaml, map[string]*bintree{}},
-			"policyconfigmap-rolebinding.yaml":  {v410KubeSchedulerPolicyconfigmapRolebindingYaml, map[string]*bintree{}},
-			"sa.yaml":                           {v410KubeSchedulerSaYaml, map[string]*bintree{}},
-			"scheduler-clusterrolebinding.yaml": {v410KubeSchedulerSchedulerClusterrolebindingYaml, map[string]*bintree{}},
-			"svc.yaml":                          {v410KubeSchedulerSvcYaml, map[string]*bintree{}},
+			"cm.yaml":                            {v410KubeSchedulerCmYaml, map[string]*bintree{}},
+			"kubeconfig-cert-syncer.yaml":        {v410KubeSchedulerKubeconfigCertSyncerYaml, map[string]*bintree{}},
+			"kubeconfig-cm.yaml":                 {v410KubeSchedulerKubeconfigCmYaml, map[string]*bintree{}},
+			"leader-election-rolebinding.yaml":   {v410KubeSchedulerLeaderElectionRolebindingYaml, map[string]*bintree{}},
+			"localhost-recovery-client-crb.yaml": {v410KubeSchedulerLocalhostRecoveryClientCrbYaml, map[string]*bintree{}},
+			"localhost-recovery-sa.yaml":         {v410KubeSchedulerLocalhostRecoverySaYaml, map[string]*bintree{}},
+			"localhost-recovery-token.yaml":      {v410KubeSchedulerLocalhostRecoveryTokenYaml, map[string]*bintree{}},
+			"ns.yaml":                            {v410KubeSchedulerNsYaml, map[string]*bintree{}},
+			"pod-cm.yaml":                        {v410KubeSchedulerPodCmYaml, map[string]*bintree{}},
+			"pod.yaml":                           {v410KubeSchedulerPodYaml, map[string]*bintree{}},
+			"policyconfigmap-role.yaml":          {v410KubeSchedulerPolicyconfigmapRoleYaml, map[string]*bintree{}},
+			"policyconfigmap-rolebinding.yaml":   {v410KubeSchedulerPolicyconfigmapRolebindingYaml, map[string]*bintree{}},
+			"sa.yaml":                            {v410KubeSchedulerSaYaml, map[string]*bintree{}},
+			"scheduler-clusterrolebinding.yaml":  {v410KubeSchedulerSchedulerClusterrolebindingYaml, map[string]*bintree{}},
+			"svc.yaml":                           {v410KubeSchedulerSvcYaml, map[string]*bintree{}},
 		}},
 	}},
 }}

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/certsyncpod/certsync_cmd.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/certsyncpod/certsync_cmd.go
@@ -1,0 +1,140 @@
+package certsyncpod
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+	"k8s.io/klog"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+
+	"github.com/openshift/library-go/pkg/config/client"
+	"github.com/openshift/library-go/pkg/controller/fileobserver"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/staticpod/controller/revision"
+)
+
+type CertSyncControllerOptions struct {
+	KubeConfigFile string
+	Namespace      string
+	DestinationDir string
+
+	configMaps []revision.RevisionResource
+	secrets    []revision.RevisionResource
+
+	kubeClient            kubernetes.Interface
+	tlsServerNameOverride string
+}
+
+func NewCertSyncControllerCommand(configmaps, secrets []revision.RevisionResource) *cobra.Command {
+	o := &CertSyncControllerOptions{
+		configMaps: configmaps,
+		secrets:    secrets,
+	}
+
+	cmd := &cobra.Command{
+		Use: "cert-syncer --kubeconfig=kubeconfigfile",
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := o.Complete(); err != nil {
+				klog.Fatal(err)
+			}
+			if err := o.Run(); err != nil {
+				klog.Fatal(err)
+			}
+		},
+	}
+
+	cmd.Flags().StringVar(&o.DestinationDir, "destination-dir", o.DestinationDir, "Directory to write to")
+	cmd.Flags().StringVarP(&o.Namespace, "namespace", "n", o.Namespace, "Namespace to read from (default to 'POD_NAMESPACE' environment variable)")
+	cmd.Flags().StringVar(&o.KubeConfigFile, "kubeconfig", o.KubeConfigFile, "Location of the master configuration file to run from.")
+	cmd.Flags().StringVar(&o.tlsServerNameOverride, "tls-server-name-override", o.tlsServerNameOverride, "Server name override used by TLS to negotiate the serving cert via SNI.")
+
+	return cmd
+}
+
+func (o *CertSyncControllerOptions) Run() error {
+	// When the kubeconfig content change, commit suicide to reload its content.
+	observer, err := fileobserver.NewObserver(500 * time.Millisecond)
+	if err != nil {
+		return err
+	}
+
+	stopCh := make(chan struct{})
+
+	// Make a context that is cancelled when stopCh is closed
+	// TODO: Replace stopCh with regular context.
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		defer cancel()
+		<-stopCh
+	}()
+
+	initialContent, _ := ioutil.ReadFile(o.KubeConfigFile)
+	observer.AddReactor(fileobserver.TerminateOnChangeReactor(func() {
+		close(stopCh)
+	}), map[string][]byte{o.KubeConfigFile: initialContent}, o.KubeConfigFile)
+
+	kubeInformers := informers.NewSharedInformerFactoryWithOptions(o.kubeClient, 10*time.Minute, informers.WithNamespace(o.Namespace))
+
+	eventRecorder := events.NewKubeRecorder(o.kubeClient.CoreV1().Events(o.Namespace), "cert-syncer",
+		&corev1.ObjectReference{
+			APIVersion: "v1",
+			Kind:       "Pod",
+			Namespace:  os.Getenv("POD_NAMESPACE"),
+			Name:       os.Getenv("POD_NAME"),
+		})
+
+	controller := NewCertSyncController(
+		o.DestinationDir,
+		o.Namespace,
+		o.configMaps,
+		o.secrets,
+		o.kubeClient,
+		kubeInformers,
+		eventRecorder,
+	)
+
+	// start everything. WithInformers start after they have been requested.
+	go controller.Run(ctx, 1)
+	go observer.Run(stopCh)
+	go kubeInformers.Start(stopCh)
+
+	<-stopCh
+	klog.Infof("Shutting down certificate syncer")
+
+	return nil
+}
+
+func (o *CertSyncControllerOptions) Complete() error {
+	kubeConfig, err := client.GetKubeConfigOrInClusterConfig(o.KubeConfigFile, nil)
+	if err != nil {
+		return err
+	}
+
+	if len(o.Namespace) == 0 && len(os.Getenv("POD_NAMESPACE")) > 0 {
+		o.Namespace = os.Getenv("POD_NAMESPACE")
+	}
+
+	protoKubeConfig := rest.CopyConfig(kubeConfig)
+	protoKubeConfig.AcceptContentTypes = "application/vnd.kubernetes.protobuf,application/json"
+	protoKubeConfig.ContentType = "application/vnd.kubernetes.protobuf"
+
+	if len(o.tlsServerNameOverride) > 0 {
+		protoKubeConfig.TLSClientConfig.ServerName = o.tlsServerNameOverride
+	}
+
+	// This kube client use protobuf, do not use it for CR
+	kubeClient, err := kubernetes.NewForConfig(protoKubeConfig)
+	if err != nil {
+		return err
+	}
+	o.kubeClient = kubeClient
+
+	return nil
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/certsyncpod/certsync_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/certsyncpod/certsync_controller.go
@@ -1,0 +1,268 @@
+package certsyncpod
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"reflect"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	corev1interface "k8s.io/client-go/kubernetes/typed/core/v1"
+	v1 "k8s.io/client-go/listers/core/v1"
+	"k8s.io/klog"
+
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/staticpod/controller/revision"
+)
+
+type CertSyncController struct {
+	destinationDir string
+	namespace      string
+	configMaps     []revision.RevisionResource
+	secrets        []revision.RevisionResource
+
+	configmapGetter corev1interface.ConfigMapInterface
+	configMapLister v1.ConfigMapLister
+	secretGetter    corev1interface.SecretInterface
+	secretLister    v1.SecretLister
+	eventRecorder   events.Recorder
+}
+
+func NewCertSyncController(targetDir, targetNamespace string, configmaps, secrets []revision.RevisionResource, kubeClient kubernetes.Interface, informers informers.SharedInformerFactory, eventRecorder events.Recorder) factory.Controller {
+	c := &CertSyncController{
+		destinationDir: targetDir,
+		namespace:      targetNamespace,
+		configMaps:     configmaps,
+		secrets:        secrets,
+		eventRecorder:  eventRecorder.WithComponentSuffix("cert-sync-controller"),
+
+		configmapGetter: kubeClient.CoreV1().ConfigMaps(targetNamespace),
+		configMapLister: informers.Core().V1().ConfigMaps().Lister(),
+		secretLister:    informers.Core().V1().Secrets().Lister(),
+		secretGetter:    kubeClient.CoreV1().Secrets(targetNamespace),
+	}
+
+	return factory.New().WithInformers(informers.Core().V1().ConfigMaps().Informer(), informers.Core().V1().Secrets().Informer()).WithSync(c.sync).ToController("CertSyncController", eventRecorder)
+}
+
+func getConfigMapDir(targetDir, configMapName string) string {
+	return filepath.Join(targetDir, "configmaps", configMapName)
+}
+
+func getSecretDir(targetDir, secretName string) string {
+	return filepath.Join(targetDir, "secrets", secretName)
+}
+
+func (c *CertSyncController) sync(ctx context.Context, syncCtx factory.SyncContext) error {
+	errors := []error{}
+
+	klog.Infof("Syncing configmaps: %v", c.configMaps)
+	for _, cm := range c.configMaps {
+		configMap, err := c.configMapLister.ConfigMaps(c.namespace).Get(cm.Name)
+		switch {
+		case apierrors.IsNotFound(err) && !cm.Optional:
+			errors = append(errors, err)
+			continue
+
+		case apierrors.IsNotFound(err) && cm.Optional:
+			// Check with the live call it is really missing
+			configMap, err = c.configmapGetter.Get(cm.Name, metav1.GetOptions{})
+			if err == nil {
+				klog.Infof("Caches are stale. They don't see configmap '%s/%s', yet it is present", configMap.Namespace, configMap.Name)
+				// We will get re-queued when we observe the change
+				continue
+			}
+			if !apierrors.IsNotFound(err) {
+				errors = append(errors, err)
+				continue
+			}
+
+			// remove missing content
+			if err := os.RemoveAll(getConfigMapDir(c.destinationDir, cm.Name)); err != nil {
+				c.eventRecorder.Warningf("CertificateUpdateFailed", "Failed removing file for configmap: %s/%s: %v", c.namespace, cm.Name, err)
+				errors = append(errors, err)
+			}
+			c.eventRecorder.Eventf("CertificateRemoved", "Removed file for configmap: %s/%s", c.namespace, cm.Name)
+			continue
+
+		case err != nil:
+			c.eventRecorder.Warningf("CertificateUpdateFailed", "Failed getting configmap: %s/%s: %v", c.namespace, cm.Name, err)
+			errors = append(errors, err)
+			continue
+		}
+
+		contentDir := getConfigMapDir(c.destinationDir, cm.Name)
+
+		data := map[string]string{}
+		for filename := range configMap.Data {
+			fullFilename := filepath.Join(contentDir, filename)
+
+			existingContent, err := ioutil.ReadFile(fullFilename)
+			if err != nil {
+				if !os.IsNotExist(err) {
+					klog.Error(err)
+				}
+				continue
+			}
+
+			data[filename] = string(existingContent)
+		}
+
+		// Check if cached configmap differs
+		if reflect.DeepEqual(configMap.Data, data) {
+			continue
+		}
+
+		klog.V(2).Infof("Syncing updated configmap '%s/%s'.", configMap.Namespace, configMap.Name)
+
+		// We need to do a live get here so we don't overwrite a newer file with one from a stale cache
+		configMap, err = c.configmapGetter.Get(configMap.Name, metav1.GetOptions{})
+		if err != nil {
+			// Even if the error is not exists we will act on it when caches catch up
+			c.eventRecorder.Warningf("CertificateUpdateFailed", "Failed getting configmap: %s/%s: %v", c.namespace, cm.Name, err)
+			errors = append(errors, err)
+			continue
+		}
+
+		// Check if the live configmap differs
+		if reflect.DeepEqual(configMap.Data, data) {
+			klog.Infof("Caches are stale. The live configmap '%s/%s' is reflected on filesystem, but cached one differs", configMap.Namespace, configMap.Name)
+			continue
+		}
+
+		klog.Infof("Creating directory %q ...", contentDir)
+		if err := os.MkdirAll(contentDir, 0755); err != nil && !os.IsExist(err) {
+			c.eventRecorder.Warningf("CertificateUpdateFailed", "Failed creating directory for configmap: %s/%s: %v", configMap.Namespace, configMap.Name, err)
+			errors = append(errors, err)
+			continue
+		}
+		for filename, content := range configMap.Data {
+			fullFilename := filepath.Join(contentDir, filename)
+			// if the existing is the same, do nothing
+			if reflect.DeepEqual(data[fullFilename], content) {
+				continue
+			}
+
+			klog.Infof("Writing configmap manifest %q ...", fullFilename)
+			if err := ioutil.WriteFile(fullFilename, []byte(content), 0644); err != nil {
+				c.eventRecorder.Warningf("CertificateUpdateFailed", "Failed writing file for configmap: %s/%s: %v", configMap.Namespace, configMap.Name, err)
+				errors = append(errors, err)
+				continue
+			}
+		}
+		c.eventRecorder.Eventf("CertificateUpdated", "Wrote updated configmap: %s/%s", configMap.Namespace, configMap.Name)
+	}
+
+	klog.Infof("Syncing secrets: %v", c.secrets)
+	for _, s := range c.secrets {
+		secret, err := c.secretLister.Secrets(c.namespace).Get(s.Name)
+		switch {
+		case apierrors.IsNotFound(err) && !s.Optional:
+			errors = append(errors, err)
+			continue
+
+		case apierrors.IsNotFound(err) && s.Optional:
+			// Check with the live call it is really missing
+			secret, err = c.secretGetter.Get(s.Name, metav1.GetOptions{})
+			if err == nil {
+				klog.Infof("Caches are stale. They don't see secret '%s/%s', yet it is present", secret.Namespace, secret.Name)
+				// We will get re-queued when we observe the change
+				continue
+			}
+			if !apierrors.IsNotFound(err) {
+				errors = append(errors, err)
+				continue
+			}
+
+			// check if the secret file exists, skip firing events if it does not
+			secretFile := getSecretDir(c.destinationDir, s.Name)
+			if _, err := os.Stat(secretFile); os.IsNotExist(err) {
+				continue
+			}
+
+			// remove missing content
+			if err := os.RemoveAll(secretFile); err != nil {
+				c.eventRecorder.Warningf("CertificateUpdateFailed", "Failed removing file for missing secret: %s/%s: %v", c.namespace, s.Name, err)
+				errors = append(errors, err)
+				continue
+			}
+			c.eventRecorder.Warningf("CertificateRemoved", "Removed file for missing secret: %s/%s", c.namespace, s.Name)
+			continue
+
+		case err != nil:
+			c.eventRecorder.Warningf("CertificateUpdateFailed", "Failed getting secret: %s/%s: %v", c.namespace, s.Name, err)
+			errors = append(errors, err)
+			continue
+		}
+
+		contentDir := getSecretDir(c.destinationDir, s.Name)
+
+		data := map[string][]byte{}
+		for filename := range secret.Data {
+			fullFilename := filepath.Join(contentDir, filename)
+
+			existingContent, err := ioutil.ReadFile(fullFilename)
+			if err != nil {
+				if !os.IsNotExist(err) {
+					klog.Error(err)
+				}
+				continue
+			}
+
+			data[filename] = existingContent
+		}
+
+		// Check if cached secret differs
+		if reflect.DeepEqual(secret.Data, data) {
+			continue
+		}
+
+		klog.V(2).Infof("Syncing updated secret '%s/%s'.", secret.Namespace, secret.Name)
+
+		// We need to do a live get here so we don't overwrite a newer file with one from a stale cache
+		secret, err = c.secretGetter.Get(secret.Name, metav1.GetOptions{})
+		if err != nil {
+			// Even if the error is not exists we will act on it when caches catch up
+			c.eventRecorder.Warningf("CertificateUpdateFailed", "Failed getting secret: %s/%s: %v", c.namespace, s.Name, err)
+			errors = append(errors, err)
+			continue
+		}
+
+		// Check if the live secret differs
+		if reflect.DeepEqual(secret.Data, data) {
+			klog.Infof("Caches are stale. The live secret '%s/%s' is reflected on filesystem, but cached one differs", secret.Namespace, secret.Name)
+			continue
+		}
+
+		klog.Infof("Creating directory %q ...", contentDir)
+		if err := os.MkdirAll(contentDir, 0755); err != nil && !os.IsExist(err) {
+			c.eventRecorder.Warningf("CertificateUpdateFailed", "Failed creating directory for secret: %s/%s: %v", secret.Namespace, secret.Name, err)
+			errors = append(errors, err)
+			continue
+		}
+		for filename, content := range secret.Data {
+			// TODO fix permissions
+			fullFilename := filepath.Join(contentDir, filename)
+			// if the existing is the same, do nothing
+			if reflect.DeepEqual(data[fullFilename], content) {
+				continue
+			}
+
+			klog.Infof("Writing secret manifest %q ...", fullFilename)
+			if err := ioutil.WriteFile(fullFilename, content, 0644); err != nil {
+				c.eventRecorder.Warningf("CertificateUpdateFailed", "Failed writing file for secret: %s/%s: %v", secret.Namespace, secret.Name, err)
+				errors = append(errors, err)
+				continue
+			}
+		}
+		c.eventRecorder.Eventf("CertificateUpdated", "Wrote updated secret: %s/%s", secret.Namespace, secret.Name)
+	}
+
+	return utilerrors.NewAggregate(errors)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -190,6 +190,7 @@ github.com/openshift/library-go/pkg/operator/resourcesynccontroller
 github.com/openshift/library-go/pkg/operator/revisioncontroller
 github.com/openshift/library-go/pkg/operator/staleconditions
 github.com/openshift/library-go/pkg/operator/staticpod
+github.com/openshift/library-go/pkg/operator/staticpod/certsyncpod
 github.com/openshift/library-go/pkg/operator/staticpod/controller/backingresource
 github.com/openshift/library-go/pkg/operator/staticpod/controller/backingresource/bindata
 github.com/openshift/library-go/pkg/operator/staticpod/controller/installer


### PR DESCRIPTION
kube-scheduler is required to be operational if we are starting after downtime or after cert regeneration and all the regular pods are down. There is no operator to create new installer pods so we need scheduler up first. That also means it has to be able to reload refreshed certs. Kubelet also needs sdn to be running for installer pods to work as they use service network and sdn needs scheduler to run.

/hold
this needs client cert reload in origin first https://github.com/openshift/origin/pull/24646
 
/cc @deads2k @soltysh 