### PR TITLE
Bug 1812583: Normalize CPU requests on masters

### DIFF
--- a/bindata/v4.1.0/kube-scheduler/pod.yaml
+++ b/bindata/v4.1.0/kube-scheduler/pod.yaml
@@ -36,6 +36,7 @@ spec:
     resources:
       requests:
         memory: 50Mi
+        cpu: 15m
     ports:
     - containerPort: 10259
     volumeMounts:
@@ -78,7 +79,7 @@ spec:
     resources:
       requests:
         memory: 50Mi
-        cpu: 10m
+        cpu: 5m
     volumeMounts:
       - mountPath: /etc/kubernetes/static-pod-resources
         name: resource-dir

--- a/pkg/operator/v410_00_assets/bindata.go
+++ b/pkg/operator/v410_00_assets/bindata.go
@@ -408,6 +408,7 @@ spec:
     resources:
       requests:
         memory: 50Mi
+        cpu: 15m
     ports:
     - containerPort: 10259
     volumeMounts:
@@ -450,7 +451,7 @@ spec:
     resources:
       requests:
         memory: 50Mi
-        cpu: 10m
+        cpu: 5m
     volumeMounts:
       - mountPath: /etc/kubernetes/static-pod-resources
         name: resource-dir


### PR DESCRIPTION
The ks uses less than 1% of master CPU in a reasonable medium
sized workload. The ks can be bursty in certain scenarios.

Given a 1 core per master baseline (since CPU is compressible and
shared), assign the ks roughly 1.5% of that core on each master
(1/20 of the kube-apiserver usage).