### PR TITLE
Bump TraceAll log level to v=10

### DIFF
--- a/pkg/operator/target_config_reconciler_v410_00.go
+++ b/pkg/operator/target_config_reconciler_v410_00.go
@@ -141,7 +141,9 @@ func managePod_v311_00_to_latest(ctx context.Context, configMapsGetter corev1cli
 	case operatorv1.Trace:
 		required.Spec.Containers[0].Args = append(required.Spec.Containers[0].Args, fmt.Sprintf("-v=%d", 6))
 	case operatorv1.TraceAll:
-		required.Spec.Containers[0].Args = append(required.Spec.Containers[0].Args, fmt.Sprintf("-v=%d", 8))
+		// We use V(10) here because many critical debugging logs from the scheduler are set to loglevel 10 upstream,
+		// such as node scores when running priority plugins. See https://github.com/openshift/cluster-kube-scheduler-operator/pull/232
+		required.Spec.Containers[0].Args = append(required.Spec.Containers[0].Args, fmt.Sprintf("-v=%d", 10))
 	default:
 		required.Spec.Containers[0].Args = append(required.Spec.Containers[0].Args, fmt.Sprintf("-v=%d", 2))
 	}


### PR DESCRIPTION
Fixes https://github.com/openshift/cluster-kube-scheduler-operator/issues/231

Many critical spots in the scheduler code log at level `V(10)`, which is higher than our current `TraceAll` standard of 8. That means that in order to get certain helpful messages, developers currently need to manually hack the scheduler deployment to pass a `--v=10` flag which is not ideal when they could just use the loglevel setting in the operator spec.

Examples of these logs are:
* Node scores when prioritizing: https://github.com/kubernetes/kubernetes/blob/master/pkg/scheduler/core/generic_scheduler.go#L650-L654
* Several plugins' debugging information:
    * https://github.com/kubernetes/kubernetes/blob/master/pkg/scheduler/framework/plugins/volumezone/volume_zone.go#L167
    * https://github.com/kubernetes/kubernetes/blob/master/pkg/scheduler/framework/plugins/noderesources/resource_allocation.go#L70-L84
    * https://github.com/kubernetes/kubernetes/blob/master/pkg/scheduler/framework/plugins/interpodaffinity/filtering.go#L410-L414

Though there are fewer usages of `V(10)` than in the past, it is still the usual log level for important debugging information within the scheduler