### PR TITLE
[wip] Switch to v1alpha2 componentconfig

### DIFF
--- a/bindata/v4.1.0/config/defaultconfig-postbootstrap.yaml
+++ b/bindata/v4.1.0/config/defaultconfig-postbootstrap.yaml
@@ -1,8 +1,8 @@
-apiVersion: kubescheduler.config.k8s.io/v1alpha1
+apiVersion: kubescheduler.config.k8s.io/v1alpha2
 kind: KubeSchedulerConfiguration
 clientConnection:
   kubeconfig: /etc/kubernetes/static-pod-resources/configmaps/scheduler-kubeconfig/kubeconfig
 leaderElection:
   leaderElect: true
-  lockObjectNamespace: "openshift-kube-scheduler"
+  resourceNamespace: "openshift-kube-scheduler"
   resourceLock: "configmaps"

--- a/bindata/v4.1.0/config/defaultconfig.yaml
+++ b/bindata/v4.1.0/config/defaultconfig.yaml
@@ -1,2 +1,2 @@
-apiVersion: kubescheduler.config.k8s.io/v1alpha1
+apiVersion: kubescheduler.config.k8s.io/v1alpha2
 kind: KubeSchedulerConfiguration

--- a/pkg/operator/v410_00_assets/bindata.go
+++ b/pkg/operator/v410_00_assets/bindata.go
@@ -70,13 +70,13 @@ func (fi bindataFileInfo) Sys() interface{} {
 	return nil
 }
 
-var _v410ConfigDefaultconfigPostbootstrapYaml = []byte(`apiVersion: kubescheduler.config.k8s.io/v1alpha1
+var _v410ConfigDefaultconfigPostbootstrapYaml = []byte(`apiVersion: kubescheduler.config.k8s.io/v1alpha2
 kind: KubeSchedulerConfiguration
 clientConnection:
   kubeconfig: /etc/kubernetes/static-pod-resources/configmaps/scheduler-kubeconfig/kubeconfig
 leaderElection:
   leaderElect: true
-  lockObjectNamespace: "openshift-kube-scheduler"
+  resourceNamespace: "openshift-kube-scheduler"
   resourceLock: "configmaps"
 `)
 
@@ -95,7 +95,7 @@ func v410ConfigDefaultconfigPostbootstrapYaml() (*asset, error) {
 	return a, nil
 }
 
-var _v410ConfigDefaultconfigYaml = []byte(`apiVersion: kubescheduler.config.k8s.io/v1alpha1
+var _v410ConfigDefaultconfigYaml = []byte(`apiVersion: kubescheduler.config.k8s.io/v1alpha2
 kind: KubeSchedulerConfiguration
 `)
 


### PR DESCRIPTION
See https://github.com/openshift/cluster-kube-scheduler-operator/issues/197

As of 1.19 the v1alpha1 scheduler config will be removed. We need to update our operator to use the new componentconfig (and docs to reflect the policy/plugin config change)