### PR TITLE
Bug 1801437: bump(*): Mark Abandoned static pod revisions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/openshift/api v0.0.0-20200521101457-60c476765272
 	github.com/openshift/build-machinery-go v0.0.0-20200512074546-3744767c4131
 	github.com/openshift/client-go v0.0.0-20200521150516-05eb9880269c
-	github.com/openshift/library-go v0.0.0-20200526124911-cd27f9384ffc
+	github.com/openshift/library-go v0.0.0-20200527213645-a9b77f5402e3
 	github.com/prometheus/client_golang v1.1.0
 	github.com/prometheus/common v0.6.0
 	github.com/spf13/cobra v0.0.5

--- a/go.sum
+++ b/go.sum
@@ -299,8 +299,8 @@ github.com/openshift/build-machinery-go v0.0.0-20200512074546-3744767c4131 h1:JW
 github.com/openshift/build-machinery-go v0.0.0-20200512074546-3744767c4131/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20200521150516-05eb9880269c h1:l7CmbzzkyWl4Y6qHmy6m4FvbH4iLnIXGrXqOfE5IFNA=
 github.com/openshift/client-go v0.0.0-20200521150516-05eb9880269c/go.mod h1:kCMeo6IE4o4qvnepM9lgHQ4j/ZFfvY/N/2G/jpJdwm4=
-github.com/openshift/library-go v0.0.0-20200526124911-cd27f9384ffc h1:qevDj2hJCiW1Ye6HI88rRg5axM4wrmgsR8+8XXr2DfA=
-github.com/openshift/library-go v0.0.0-20200526124911-cd27f9384ffc/go.mod h1:dJqjuQMmC/T1nhi5yGbRf7qGxnO+vRa2j99y6oVYDZQ=
+github.com/openshift/library-go v0.0.0-20200527213645-a9b77f5402e3 h1:xCOXlKSaInOrnS1iTwzB44Co+4FQCykmb8GZcji4K8M=
+github.com/openshift/library-go v0.0.0-20200527213645-a9b77f5402e3/go.mod h1:dJqjuQMmC/T1nhi5yGbRf7qGxnO+vRa2j99y6oVYDZQ=
 github.com/pborman/uuid v1.2.0 h1:J7Q5mO4ysT1dv8hyrUGHb9+ooztCXu1D8MY8DZYsu3g=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/vendor/github.com/openshift/library-go/pkg/operator/revisioncontroller/revision_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/revisioncontroller/revision_controller.go
@@ -21,6 +21,7 @@ import (
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/management"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
+	"github.com/openshift/library-go/pkg/operator/staticpod/controller/prune"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 )
 
@@ -191,13 +192,14 @@ func (c RevisionController) isLatestRevisionCurrent(revision int32) (bool, strin
 }
 
 func (c RevisionController) createNewRevision(recorder events.Recorder, revision int32) error {
+	// Create a new InProgress status configmap
 	statusConfigMap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: c.targetNamespace,
 			Name:      nameFor("revision-status", revision),
 		},
 		Data: map[string]string{
-			"status":   "InProgress",
+			"status":   prune.StatusInProgress,
 			"revision": fmt.Sprintf("%d", revision),
 		},
 	}
@@ -205,6 +207,26 @@ func (c RevisionController) createNewRevision(recorder events.Recorder, revision
 	if err != nil {
 		return err
 	}
+
+	// After we create a new revision, check if any of the previous existing
+	// revisions got interrupted while InProgress and mark them Abandoned.
+	configMaps, err := c.configMapGetter.ConfigMaps(c.targetNamespace).List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+	for _, configMap := range configMaps.Items {
+		if !strings.HasPrefix(configMap.Name, "revision-status-") || configMap.Name == statusConfigMap.Name {
+			continue
+		}
+		if configMap.Data["status"] == prune.StatusInProgress {
+			configMap.Data["status"] = prune.StatusAbandoned
+			_, _, err = resourceapply.ApplyConfigMap(c.configMapGetter, recorder, &configMap)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
 	ownerRefs := []metav1.OwnerReference{{
 		APIVersion: "v1",
 		Kind:       "ConfigMap",

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -161,7 +161,7 @@ github.com/openshift/client-go/operator/clientset/versioned/typed/operator/v1alp
 github.com/openshift/client-go/route/clientset/versioned
 github.com/openshift/client-go/route/clientset/versioned/scheme
 github.com/openshift/client-go/route/clientset/versioned/typed/route/v1
-# github.com/openshift/library-go v0.0.0-20200526124911-cd27f9384ffc
+# github.com/openshift/library-go v0.0.0-20200527213645-a9b77f5402e3
 github.com/openshift/library-go/pkg/assets
 github.com/openshift/library-go/pkg/config/client
 github.com/openshift/library-go/pkg/config/clusteroperator/v1helpers


### PR DESCRIPTION
Includes the changes from library-go/806 which check for interrupted InProgress
revisions and marks them Abandoned, then prunes Abandoned revisions.