### PR TITLE
Use ss instead of lsof when waiting for ports

### DIFF
--- a/bindata/v4.1.0/kube-scheduler/pod.yaml
+++ b/bindata/v4.1.0/kube-scheduler/pod.yaml
@@ -18,8 +18,8 @@ spec:
     command: ['/usr/bin/timeout', '30', '/bin/bash', '-c']
     args:
     - |
-      echo -n "Waiting for port :10259 and :10251 to be released."
-      while [ -n "$(lsof -ni :10251)" -o -n "$(lsof -i :10259)" ]; do
+      echo -n "Waiting for port :10251 and :10259 to be released."
+      while [ -n "$(ss -Htan '( sport = 10251 or sport = 10259 )')" ]; do
         echo -n "."
         sleep 1
       done

--- a/pkg/operator/v410_00_assets/bindata.go
+++ b/pkg/operator/v410_00_assets/bindata.go
@@ -399,8 +399,8 @@ spec:
     command: ['/usr/bin/timeout', '30', '/bin/bash', '-c']
     args:
     - |
-      echo -n "Waiting for port :10259 and :10251 to be released."
-      while [ -n "$(lsof -ni :10251)" -o -n "$(lsof -i :10259)" ]; do
+      echo -n "Waiting for port :10251 and :10259 to be released."
+      while [ -n "$(ss -Htan '( sport = 10251 or sport = 10259 )')" ]; do
         echo -n "."
         sleep 1
       done


### PR DESCRIPTION
This is coming from this change to kas-o https://github.com/openshift/cluster-kube-apiserver-operator/pull/864 for details why `ss` over `lsof` see this comment https://github.com/openshift/cluster-kube-apiserver-operator/pull/864#issuecomment-632322430.

/assign @sttts 