### PR TITLE
Switch to v1beta1 Scheduler config to bridge between Policy/Plugin APIs

### DIFF
--- a/bindata/bootkube/config/bootstrap-config-overrides.yaml
+++ b/bindata/bootkube/config/bootstrap-config-overrides.yaml
@@ -1,2 +1,2 @@
-apiVersion: kubescheduler.config.k8s.io/v1alpha1
+apiVersion: kubescheduler.config.k8s.io/v1beta1
 kind: KubeSchedulerConfiguration

--- a/bindata/v4.1.0/config/defaultconfig-postbootstrap.yaml
+++ b/bindata/v4.1.0/config/defaultconfig-postbootstrap.yaml
@@ -1,8 +1,8 @@
-apiVersion: kubescheduler.config.k8s.io/v1alpha1
+apiVersion: kubescheduler.config.k8s.io/v1beta1
 kind: KubeSchedulerConfiguration
 clientConnection:
   kubeconfig: /etc/kubernetes/static-pod-resources/configmaps/scheduler-kubeconfig/kubeconfig
 leaderElection:
   leaderElect: true
-  lockObjectNamespace: "openshift-kube-scheduler"
+  resourceNamespace: "openshift-kube-scheduler"
   resourceLock: "configmaps"

--- a/bindata/v4.1.0/config/defaultconfig.yaml
+++ b/bindata/v4.1.0/config/defaultconfig.yaml
@@ -1,2 +1,2 @@
-apiVersion: kubescheduler.config.k8s.io/v1alpha1
+apiVersion: kubescheduler.config.k8s.io/v1beta1
 kind: KubeSchedulerConfiguration

--- a/pkg/operator/configobservation/scheduler/observe_scheduler.go
+++ b/pkg/operator/configobservation/scheduler/observe_scheduler.go
@@ -2,7 +2,6 @@ package scheduler
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/klog"
 
 	"github.com/openshift/cluster-kube-scheduler-operator/pkg/operator/configobservation"
@@ -12,35 +11,15 @@ import (
 	"github.com/openshift/library-go/pkg/operator/resourcesynccontroller"
 )
 
-// observeSchedulerConfig lists the scheduler configuration and updates the name of the configmap that we want scheduler
-// to use as policy config
+// observeSchedulerConfig syncs the scheduler policy-config from the openshift-config namespace to the kube-scheduler, if set
+// TODO(@damemi): This does not currently do much besides sync and delete the policy configmap if necessary,
+//  but when we completely switch over to the ComponentConfig API, we will need to re-introduce logic here which
+//  merges policy config information into the main scheduler config. See: https://github.com/openshift/cluster-kube-scheduler-operator/pull/255
 func ObserveSchedulerConfig(genericListers configobserver.Listers, recorder events.Recorder, existingConfig map[string]interface{}) (map[string]interface{}, []error) {
 	listers := genericListers.(configobservation.Listers)
 	errs := []error{}
 	prevObservedConfig := map[string]interface{}{}
-	policyConfigMapRootPath := []string{"algorithmSource", "policy", "configMap"}
-	// Name of the policy configmap. This should come after the policyConfigMapRootPath
-	policyConfigMapNamePath := append(policyConfigMapRootPath, "name")
-	// Namespace where the policy configmap exists. This should come after the policyConfigMapRootPath
-	policyConfigMapNamespacePath := append(policyConfigMapRootPath, "namespace")
-	currentPolicyConfigMapName, _, err := unstructured.NestedString(existingConfig, policyConfigMapNamePath...)
-	if err != nil {
-		return prevObservedConfig, append(errs, err)
-	}
-	if len(currentPolicyConfigMapName) > 0 {
-		if err := unstructured.SetNestedField(prevObservedConfig, currentPolicyConfigMapName, policyConfigMapNamePath...); err != nil {
-			errs = append(errs, err)
-		}
-	}
-	currentPolicyConfigMapNamespace, _, err := unstructured.NestedString(existingConfig, policyConfigMapNamespacePath...)
-	if err != nil {
-		return prevObservedConfig, append(errs, err)
-	}
-	if len(currentPolicyConfigMapNamespace) > 0 {
-		if err := unstructured.SetNestedField(prevObservedConfig, currentPolicyConfigMapNamespace, policyConfigMapNamespacePath...); err != nil {
-			errs = append(errs, err)
-		}
-	}
+
 	sourceTargetLocation := resourcesynccontroller.ResourceLocation{}
 	observedConfig := map[string]interface{}{}
 	schedulerConfig, err := listers.SchedulerLister.Get("cluster")
@@ -81,26 +60,9 @@ func ObserveSchedulerConfig(genericListers configobserver.Listers, recorder even
 		},
 		sourceTargetLocation,
 	)
-	if len(configMapName) == 0 {
-		if len(currentPolicyConfigMapName) > 0 {
-			recorder.Eventf("ObservedConfigMapNameChanged", "scheduler configmap removed")
-			unstructured.RemoveNestedField(prevObservedConfig, "algorithmSource")
-		}
-		return prevObservedConfig, errs
-	}
 	if err != nil {
 		errs = append(errs, err)
 		return prevObservedConfig, errs
-	}
-
-	if err := unstructured.SetNestedField(observedConfig, "policy-configmap", policyConfigMapNamePath...); err != nil {
-		errs = append(errs, err)
-	}
-	if configMapName != currentPolicyConfigMapName {
-		recorder.Eventf("ObservedConfigMapNameChanged", "scheduler configmap changed to %q", configMapName)
-	}
-	if err := unstructured.SetNestedField(observedConfig, operatorclient.TargetNamespace, policyConfigMapNamespacePath...); err != nil {
-		errs = append(errs, err)
 	}
 	return observedConfig, errs
 }

--- a/pkg/operator/v410_00_assets/bindata.go
+++ b/pkg/operator/v410_00_assets/bindata.go
@@ -70,13 +70,13 @@ func (fi bindataFileInfo) Sys() interface{} {
 	return nil
 }
 
-var _v410ConfigDefaultconfigPostbootstrapYaml = []byte(`apiVersion: kubescheduler.config.k8s.io/v1alpha1
+var _v410ConfigDefaultconfigPostbootstrapYaml = []byte(`apiVersion: kubescheduler.config.k8s.io/v1beta1
 kind: KubeSchedulerConfiguration
 clientConnection:
   kubeconfig: /etc/kubernetes/static-pod-resources/configmaps/scheduler-kubeconfig/kubeconfig
 leaderElection:
   leaderElect: true
-  lockObjectNamespace: "openshift-kube-scheduler"
+  resourceNamespace: "openshift-kube-scheduler"
   resourceLock: "configmaps"
 `)
 
@@ -95,7 +95,7 @@ func v410ConfigDefaultconfigPostbootstrapYaml() (*asset, error) {
 	return a, nil
 }
 
-var _v410ConfigDefaultconfigYaml = []byte(`apiVersion: kubescheduler.config.k8s.io/v1alpha1
+var _v410ConfigDefaultconfigYaml = []byte(`apiVersion: kubescheduler.config.k8s.io/v1beta1
 kind: KubeSchedulerConfiguration
 `)
 

--- a/test/e2e/scheduler_test.go
+++ b/test/e2e/scheduler_test.go
@@ -127,22 +127,22 @@ func createSchedulerConfigMap(ctx context.Context, kclient *k8sclient.Clientset)
 
 func waitForConfigMapUpdate(ctx context.Context, kclient *k8sclient.Clientset) error {
 	return wait.PollImmediate(1*time.Second, 5*time.Minute, func() (bool, error) {
-		configMap, err := kclient.CoreV1().ConfigMaps("openshift-kube-scheduler").Get(ctx, "config", metav1.GetOptions{})
+		configMap, err := kclient.CoreV1().ConfigMaps("openshift-kube-scheduler").Get(ctx, "policy-configmap", metav1.GetOptions{})
 		if err != nil {
 			klog.Infof("error waiting for config map to exist: %v\n", err)
 			return false, nil
 		}
 		klog.Infof("Found configmap")
 		// We should have algorithmSource as key in our map which shows we have configured policy.
-		if data, ok := configMap.Data["config.yaml"]; !ok {
+		if data, ok := configMap.Data["policy.cfg"]; !ok {
 			klog.Info("Still waiting for configmap created with my policy")
 			return false, nil
 		} else {
-			if strings.Contains(data, "policy-configmap") {
-				klog.Info("Configmap created with required policy name")
+			if strings.Contains(data, "predicates") {
+				klog.Info("Configmap created")
 				return true, nil
 			} else {
-				klog.Info("Still waiting for configmap to be created with my policy-configmap")
+				klog.Info("Still waiting for configmap to be created")
 			}
 		}
 		klog.Infof("configmap %v is not yet available", configMap.Name)


### PR DESCRIPTION
(Note: This is a 1.19 blocker, see https://github.com/openshift/cluster-kube-scheduler-operator/issues/197)

The scheduler has changed from the old style of config ("Policy", which was based on Predicates and Priorities) to a new config API ("ComponentConfig", which is based on Plugins such as Filter and Score). The Policy API is officially deprecated, and will eventually be removed entirely.

Our operator currently parses Policy configs (as created in [this docs example](https://docs.openshift.com/container-platform/4.1/nodes/scheduling/nodes-scheduler-default.html)) and adds a reference to the Policy config in the `KubeSchedulerConfiguration`, which combines Predicate/Priority config with overall scheduler config.

We will be able to follow a similar approach once we have fully migrated to Plugin/ComponentConfig, because ComponentConfig also holds settings for plugin "profiles" and general scheduler configuration. However, we cannot yet fully adopt the Plugins because some names and availability have changed in the transition from Predicates/Priorities, and this will require more investigation and docs updates. (There is currently a built-in transition layer to convert Policy configs to their matching Plugins, which is what we have technically been using and will continue to take advantage of in this PR).

This PR uses the (deprecated) `--policy-configmap` and `--policy-configmap-namespace` flags to update the scheduler pod with this information when the operator spec is changed. The policy configmap will still be copied by the resource sync controller under a known name to the target namespace. However this means that we no longer need to (or are even able to) configure the `algorithmSource` fields in the config observer.

When we eventually switch to full ComponentConfig/Plugin setup: ComponentConfig accepts the entire Plugin set (the equivalent of the current Policy config). So prior to this PR, we only merged the configmap name into the Policy config. In ComponentConfig, we will merge the entire "policy-configmap" contents into the CC (because CC does not simply accept a reference to the configmap).