### PR TITLE
Hack: Internally convert alpha ComponentConfig settings to kube-scheduler flags

### DIFF
--- a/bindata/v4.1.0/kube-scheduler/pod.yaml
+++ b/bindata/v4.1.0/kube-scheduler/pod.yaml
@@ -30,7 +30,6 @@ spec:
     terminationMessagePolicy: FallbackToLogsOnError
     command: ["hyperkube", "kube-scheduler"]
     args:
-    - --config=/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml
     - --cert-dir=/var/run/kubernetes
     - --port=0
     - --authentication-kubeconfig=/etc/kubernetes/static-pod-resources/configmaps/scheduler-kubeconfig/kubeconfig

--- a/pkg/operator/v410_00_assets/bindata.go
+++ b/pkg/operator/v410_00_assets/bindata.go
@@ -411,7 +411,6 @@ spec:
     terminationMessagePolicy: FallbackToLogsOnError
     command: ["hyperkube", "kube-scheduler"]
     args:
-    - --config=/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml
     - --cert-dir=/var/run/kubernetes
     - --port=0
     - --authentication-kubeconfig=/etc/kubernetes/static-pod-resources/configmaps/scheduler-kubeconfig/kubeconfig


### PR DESCRIPTION
This is meant as a temporary fix to get the 1.19 rebase to function. Once that
is accomplished, this should be immediately dropped for an actual conversion to v1beta1.

Because the alpha CC API was removed in 1.19 in favor of v1beta1, our current operator
cannot pass configuration options to the scheduler because it is built on the alpha API.
And because 1.19 will only accept the v1beta1 CC API, this prevents us from landing a
rebase (due to the scheduler not receiving basic configuration settings, like LeaderElection).

This also prevents us from importing both APIs and converting between the types, because they
are not available in the same version.

Thus the solution presented here is to *manually convert* each available CC option to its corresponding
flag. Unfortunately, not every CC field *has* a corresponding flag. In these cases, those features are
alpha, and their support was never guaranteed. They are marked with "TODO?" in these changes.