### PR TITLE
Switch to v1alpha2 ComponentConfig API

### DIFF
--- a/bindata/v4.1.0/config/defaultconfig-postbootstrap.yaml
+++ b/bindata/v4.1.0/config/defaultconfig-postbootstrap.yaml
@@ -1,8 +1,8 @@
-apiVersion: kubescheduler.config.k8s.io/v1alpha1
+apiVersion: kubescheduler.config.k8s.io/v1alpha2
 kind: KubeSchedulerConfiguration
 clientConnection:
   kubeconfig: /etc/kubernetes/static-pod-resources/configmaps/scheduler-kubeconfig/kubeconfig
 leaderElection:
   leaderElect: true
-  lockObjectNamespace: "openshift-kube-scheduler"
+  resourceNamespace: "openshift-kube-scheduler"
   resourceLock: "configmaps"

--- a/bindata/v4.1.0/config/defaultconfig.yaml
+++ b/bindata/v4.1.0/config/defaultconfig.yaml
@@ -1,2 +1,2 @@
-apiVersion: kubescheduler.config.k8s.io/v1alpha1
+apiVersion: kubescheduler.config.k8s.io/v1alpha2
 kind: KubeSchedulerConfiguration

--- a/pkg/operator/configobservation/scheduler/observe_scheduler.go
+++ b/pkg/operator/configobservation/scheduler/observe_scheduler.go
@@ -11,8 +11,10 @@ import (
 	"github.com/openshift/library-go/pkg/operator/resourcesynccontroller"
 )
 
-// observeSchedulerConfig lists the scheduler configuration and updates the name of the configmap that we want scheduler
-// to use as policy config
+// observeSchedulerConfig syncs the scheduler policy-config from the openshift-config namespace to the kube-scheduler, if set
+// TODO(@damemi): This does not currently do much besides sync and delete the policy configmap if necessary,
+//  but when we completely switch over to the ComponentConfig API, we will need to re-introduce logic here which
+//  merges policy config information into the main scheduler config. See: https://github.com/openshift/cluster-kube-scheduler-operator/pull/255
 func ObserveSchedulerConfig(genericListers configobserver.Listers, recorder events.Recorder, existingConfig map[string]interface{}) (map[string]interface{}, []error) {
 	listers := genericListers.(configobservation.Listers)
 	errs := []error{}

--- a/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
+++ b/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
@@ -3,6 +3,7 @@ package targetconfigcontroller
 import (
 	"context"
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 	"time"
@@ -51,6 +52,7 @@ type TargetConfigController struct {
 	configMapLister       corev1listers.ConfigMapLister
 	featureGateLister     configlistersv1.FeatureGateLister
 	featureGateCacheSync  cache.InformerSynced
+	configInformer        configinformers.SharedInformerFactory
 	// queue only ever has one item, but it has nice error handling backoff/retry semantics
 	queue workqueue.RateLimitingInterface
 }
@@ -74,6 +76,7 @@ func NewTargetConfigController(
 		configMapLister:       kubeInformersForNamespaces.ConfigMapLister(),
 		operatorClient:        operatorClient,
 		eventRecorder:         eventRecorder,
+		configInformer:        configInformer,
 
 		featureGateLister:    configInformer.Config().V1().FeatureGates().Lister(),
 		featureGateCacheSync: configInformer.Config().V1().FeatureGates().Informer().HasSynced,
@@ -237,7 +240,7 @@ func createTargetConfigController_v311_00_to_latest(c TargetConfigController, re
 	if err != nil {
 		errors = append(errors, fmt.Errorf("%q: %v", "serviceaccount/localhost-recovery-client", err))
 	}
-	_, _, err = managePod_v311_00_to_latest(c.ctx, c.kubeClient.CoreV1(), c.kubeClient.CoreV1(), recorder, operatorSpec, c.targetImagePullSpec, c.operatorImagePullSpec, c.featureGateLister)
+	_, _, err = managePod_v311_00_to_latest(c.ctx, c.kubeClient.CoreV1(), c.kubeClient.CoreV1(), recorder, operatorSpec, c.targetImagePullSpec, c.operatorImagePullSpec, c.featureGateLister, c.configInformer)
 	if err != nil {
 		errors = append(errors, fmt.Errorf("%q: %v", "configmap/kube-scheduler-pod", err))
 	}
@@ -276,7 +279,7 @@ func manageKubeSchedulerConfigMap_v311_00_to_latest(lister corev1listers.ConfigM
 	return resourceapply.ApplyConfigMap(client, recorder, requiredConfigMap)
 }
 
-func managePod_v311_00_to_latest(ctx context.Context, configMapsGetter corev1client.ConfigMapsGetter, secretsGetter corev1client.SecretsGetter, recorder events.Recorder, operatorSpec *operatorv1.StaticPodOperatorSpec, imagePullSpec, operatorImagePullSpec string, featureGateLister configlistersv1.FeatureGateLister) (*corev1.ConfigMap, bool, error) {
+func managePod_v311_00_to_latest(ctx context.Context, configMapsGetter corev1client.ConfigMapsGetter, secretsGetter corev1client.SecretsGetter, recorder events.Recorder, operatorSpec *operatorv1.StaticPodOperatorSpec, imagePullSpec, operatorImagePullSpec string, featureGateLister configlistersv1.FeatureGateLister, configInformer configinformers.SharedInformerFactory) (*corev1.ConfigMap, bool, error) {
 	required := resourceread.ReadPodV1OrDie(v410_00_assets.MustAsset("v4.1.0/kube-scheduler/pod.yaml"))
 	images := map[string]string{
 		"${IMAGE}":          imagePullSpec,
@@ -305,6 +308,12 @@ func managePod_v311_00_to_latest(ctx context.Context, configMapsGetter corev1cli
 	allFeatureGates := getFeatureGateString(sortedFeatureGates, featureGates)
 	required.Spec.Containers[0].Args = append(required.Spec.Containers[0].Args, fmt.Sprintf("--feature-gates=%v", allFeatureGates))
 
+	if len(os.Getenv("SCHEDULER_IMAGE")) != 0 {
+		required.Spec.Containers[0].Image = os.Getenv("SCHEDULER_IMAGE")
+		required.Spec.Containers[0].Command = []string{"kube-scheduler"}
+		required.Spec.Containers[0].ImagePullPolicy = "Always"
+	}
+
 	switch operatorSpec.LogLevel {
 	case operatorv1.Normal:
 		required.Spec.Containers[0].Args = append(required.Spec.Containers[0].Args, fmt.Sprintf("-v=%d", 2))
@@ -325,6 +334,15 @@ func managePod_v311_00_to_latest(ctx context.Context, configMapsGetter corev1cli
 	} else if err == nil {
 		required.Spec.Containers[0].Args = append(required.Spec.Containers[0].Args, "--tls-cert-file=/etc/kubernetes/static-pod-resources/secrets/serving-cert/tls.crt")
 		required.Spec.Containers[0].Args = append(required.Spec.Containers[0].Args, "--tls-private-key-file=/etc/kubernetes/static-pod-resources/secrets/serving-cert/tls.key")
+	}
+
+	config, err := configInformer.Config().V1().Schedulers().Lister().Get("cluster")
+	if err != nil {
+		return nil, false, err
+	}
+	if len(config.Spec.Policy.Name) > 0 {
+		required.Spec.Containers[0].Args = append(required.Spec.Containers[0].Args, "--policy-configmap=policy-configmap")
+		required.Spec.Containers[0].Args = append(required.Spec.Containers[0].Args, fmt.Sprintf("--policy-configmap-namespace=%s", operatorclient.TargetNamespace))
 	}
 
 	configMap := resourceread.ReadConfigMapV1OrDie(v410_00_assets.MustAsset("v4.1.0/kube-scheduler/pod-cm.yaml"))

--- a/pkg/operator/v410_00_assets/bindata.go
+++ b/pkg/operator/v410_00_assets/bindata.go
@@ -70,13 +70,13 @@ func (fi bindataFileInfo) Sys() interface{} {
 	return nil
 }
 
-var _v410ConfigDefaultconfigPostbootstrapYaml = []byte(`apiVersion: kubescheduler.config.k8s.io/v1alpha1
+var _v410ConfigDefaultconfigPostbootstrapYaml = []byte(`apiVersion: kubescheduler.config.k8s.io/v1alpha2
 kind: KubeSchedulerConfiguration
 clientConnection:
   kubeconfig: /etc/kubernetes/static-pod-resources/configmaps/scheduler-kubeconfig/kubeconfig
 leaderElection:
   leaderElect: true
-  lockObjectNamespace: "openshift-kube-scheduler"
+  resourceNamespace: "openshift-kube-scheduler"
   resourceLock: "configmaps"
 `)
 
@@ -95,7 +95,7 @@ func v410ConfigDefaultconfigPostbootstrapYaml() (*asset, error) {
 	return a, nil
 }
 
-var _v410ConfigDefaultconfigYaml = []byte(`apiVersion: kubescheduler.config.k8s.io/v1alpha1
+var _v410ConfigDefaultconfigYaml = []byte(`apiVersion: kubescheduler.config.k8s.io/v1alpha2
 kind: KubeSchedulerConfiguration
 `)
 


### PR DESCRIPTION
This is an alternative to https://github.com/openshift/cluster-kube-scheduler-operator/pull/255 (which jumps from v1alpha1 directly to v1beta1 and does not currently pass CI because v1beta1 is not available until 1.19).

v1alpha2 contains the same essential changes required for the operator to be compatible (specifically, the removal of `algorithmSource` and the switch to `Profiles` for plugin config), and is available in 1.18. So this PR should pass CI and at least serve as a POC for #255.

However, this will still run into the same problem as #255 during the rebase, in that v1alpha2 was removed at the same time v1beta1 was added (actually it was renamed to v1beta1, but it's the same effect). Because of that, even if we merge this change we'll still need to carry a patch to support both APIs in the rebase (https://github.com/kubernetes/kubernetes/commit/852442c0ff820823d21b1afa2b5b5e3896947ce3). It just may be easier (or make more sense) to carry v1alpha2 instead of v1alpha1