### PR TITLE
Drop code that expects the config map in openshift-config namespace to have policy-configmap name

### DIFF
--- a/pkg/operator/resourcesynccontroller/resourcesynccontroller.go
+++ b/pkg/operator/resourcesynccontroller/resourcesynccontroller.go
@@ -2,9 +2,7 @@ package resourcesynccontroller
 
 import (
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/klog/v2"
 
-	configinformers "github.com/openshift/client-go/config/informers/externalversions"
 	"github.com/openshift/cluster-kube-scheduler-operator/pkg/operator/operatorclient"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/resourcesynccontroller"
@@ -14,7 +12,6 @@ import (
 func NewResourceSyncController(
 	operatorConfigClient v1helpers.OperatorClient,
 	kubeInformersForNamespaces v1helpers.KubeInformersForNamespaces,
-	configInformer configinformers.SharedInformerFactory,
 	kubeClient kubernetes.Interface,
 	eventRecorder events.Recorder) (*resourcesynccontroller.ResourceSyncController, error) {
 
@@ -26,17 +23,6 @@ func NewResourceSyncController(
 		eventRecorder,
 	)
 
-	scheduler, err := configInformer.Config().V1().Schedulers().Lister().Get("cluster")
-	if err != nil {
-		klog.Infof("Error while listing scheduler %v", err)
-	}
-	if scheduler != nil && len(scheduler.Spec.Policy.Name) > 0 {
-		if err := resourceSyncController.SyncConfigMap(
-			resourcesynccontroller.ResourceLocation{Namespace: operatorclient.TargetNamespace, Name: scheduler.Spec.Policy.Name},
-			resourcesynccontroller.ResourceLocation{Namespace: operatorclient.GlobalUserSpecifiedConfigNamespace, Name: "policy-configmap"}); err != nil {
-			return nil, err
-		}
-	}
 	if err := resourceSyncController.SyncSecret(
 		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.TargetNamespace, Name: "kube-scheduler-client-cert-key"},
 		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.GlobalMachineSpecifiedConfigNamespace, Name: "kube-scheduler-client-cert-key"},

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -56,7 +56,6 @@ func RunOperator(ctx context.Context, cc *controllercmd.ControllerContext) error
 	resourceSyncController, err := resourcesynccontroller.NewResourceSyncController(
 		operatorClient,
 		kubeInformersForNamespaces,
-		configInformers,
 		kubeClient,
 		cc.EventRecorder,
 	)


### PR DESCRIPTION
Copy pasting `openshift-config/CMName` to `openshift-kube-scheduler/policy-configmap` is already carried out in the [config observer code](https://github.com/openshift/cluster-kube-scheduler-operator/blob/2f782886a6ffb61e52c9c0aa5d8dc842eb85125f/pkg/operator/configobservation/scheduler/observe_scheduler.go#L47-L52). Also, resource sync controller only copy pastes the user specified config when it's `policy-configmap` named (`SyncConfigMap` has the first argument as a destination. the second one as a source).