### PR TITLE
Allow to customize the scheduler image

### DIFF
--- a/vendor/github.com/openshift/api/config/v1/types_scheduling.go
+++ b/vendor/github.com/openshift/api/config/v1/types_scheduling.go
@@ -60,6 +60,14 @@ type SchedulerSpec struct {
 	// Please turn on this field after doing due diligence.
 	// +optional
 	MastersSchedulable bool `json:"mastersSchedulable"`
+	// CustomSchedulerImage allows to override the default scheduler image
+	// set through IMAGE environment variable in the scheduler operator
+	// deployment manifest.
+	// Important Note: It's completely at your own risk to provide
+	// a custom image. Read available documentation to make sure
+	// all the required bits are provided by the custom image.
+	// +optional
+	CustomSchedulerImage string `json:"customSchedulerImage"`
 }
 
 type SchedulerStatus struct {


### PR DESCRIPTION
To allow to replace the default scheduler with a custom one

Fixes: https://github.com/openshift/cluster-kube-scheduler-operator/issues/263

For testing purposes setting the custom image to `quay.io/openshift/origin-hyperkube:4.6.0` (should be ~1:1 to the default one).

https://github.com/openshift/api/pull/712 needs to be merged first.

TODO:
- [ ] - tests
- [ ] - docs