### PR TITLE
Bug 1907998: Collect /metrics/resources from scheduler

### DIFF
--- a/manifests/0000_90_kube-scheduler-operator_04_servicemonitor-scheduler.yaml
+++ b/manifests/0000_90_kube-scheduler-operator_04_servicemonitor-scheduler.yaml
@@ -1,4 +1,14 @@
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: prometheus-k8s-scheduler-resources
+rules:
+- nonResourceURLs:
+  - /metrics/resources
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: prometheus-k8s
@@ -35,6 +45,19 @@ subjects:
   name: prometheus-k8s
   namespace: openshift-monitoring
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus-k8s-scheduler-resources
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus-k8s-scheduler-resources
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: openshift-monitoring
+---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -50,6 +73,15 @@ spec:
   endpoints:
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
     interval: 30s
+    path: /metrics
+    port: https
+    scheme: https
+    tlsConfig:
+      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+      serverName: scheduler.openshift-kube-scheduler.svc
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    interval: 30s
+    path: /metrics/resources
     port: https
     scheme: https
     tlsConfig:


### PR DESCRIPTION
As part of KEP 1916, resource consumption from pods will be tracked by the scheduler and reported. This commit will allow that endpoint to be scraped once that code is available.  This enables those metrics to be scraped.  It adds roughly 1 series per pod on average (pods usually declare ~1 resource request on average).

From the e2e run, showing the sum of requested resources for the cluster

![image](https://user-images.githubusercontent.com/1163175/102241919-83779b80-3ec7-11eb-8881-8c5af07be66d.png)

Subsequent releases will add resource capacity dashboards.