### PR TITLE
Bug 1881322: Sync new kube-scheduler-client-cert-key on recovery

### DIFF
--- a/bindata/v4.1.0/kube-scheduler/pod.yaml
+++ b/bindata/v4.1.0/kube-scheduler/pod.yaml
@@ -87,6 +87,30 @@ spec:
         name: resource-dir
       - mountPath: /etc/kubernetes/static-pod-certs
         name: cert-dir
+  - name: kube-scheduler-recovery-controller
+    env:
+    - name: POD_NAMESPACE
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
+    image: ${OPERATOR_IMAGE}
+    imagePullPolicy: IfNotPresent
+    terminationMessagePolicy: FallbackToLogsOnError
+    command: ["/bin/bash", "-euxo", "pipefail", "-c"]
+    args:
+      - |
+        timeout 3m /bin/bash -exuo pipefail -c 'while [ -n "$(ss -Htanop \( sport = 10443 \))" ]; do sleep 1; done'
+
+        exec cluster-kube-scheduler-operator cert-recovery-controller --kubeconfig=/etc/kubernetes/static-pod-resources/configmaps/kube-scheduler-cert-syncer-kubeconfig/kubeconfig  --namespace=${POD_NAMESPACE} --listen=0.0.0.0:10443 -v=2
+    resources:
+      requests:
+        memory: 50Mi
+        cpu: 5m
+    volumeMounts:
+      - mountPath: /etc/kubernetes/static-pod-resources
+        name: resource-dir
+      - mountPath: /etc/kubernetes/static-pod-certs
+        name: cert-dir
   hostNetwork: true
   priorityClassName: system-node-critical
   tolerations:

--- a/cmd/cluster-kube-scheduler-operator/main.go
+++ b/cmd/cluster-kube-scheduler-operator/main.go
@@ -1,24 +1,24 @@
 package main
 
 import (
+	"context"
 	goflag "flag"
 	"fmt"
 	"math/rand"
 	"os"
 	"time"
 
-	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
-
-	utilflag "k8s.io/component-base/cli/flag"
-	"k8s.io/component-base/logs"
-
 	"github.com/openshift/cluster-kube-scheduler-operator/cmd/render"
 	operatorcmd "github.com/openshift/cluster-kube-scheduler-operator/pkg/cmd/operator"
+	"github.com/openshift/cluster-kube-scheduler-operator/pkg/cmd/recoverycontroller"
 	"github.com/openshift/cluster-kube-scheduler-operator/pkg/operator"
 	"github.com/openshift/library-go/pkg/operator/staticpod/certsyncpod"
 	"github.com/openshift/library-go/pkg/operator/staticpod/installerpod"
 	"github.com/openshift/library-go/pkg/operator/staticpod/prune"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	utilflag "k8s.io/component-base/cli/flag"
+	"k8s.io/component-base/logs"
 )
 
 func main() {
@@ -30,14 +30,14 @@ func main() {
 	logs.InitLogs()
 	defer logs.FlushLogs()
 
-	command := NewSchedulerOperatorCommand()
+	command := NewSchedulerOperatorCommand(context.Background())
 	if err := command.Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)
 	}
 }
 
-func NewSchedulerOperatorCommand() *cobra.Command {
+func NewSchedulerOperatorCommand(ctx context.Context) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "cluster-kube-scheduler-operator",
 		Short: "OpenShift cluster kube-scheduler operator",
@@ -52,6 +52,7 @@ func NewSchedulerOperatorCommand() *cobra.Command {
 	cmd.AddCommand(installerpod.NewInstaller())
 	cmd.AddCommand(prune.NewPrune())
 	cmd.AddCommand(certsyncpod.NewCertSyncControllerCommand(operator.CertConfigMaps, operator.CertSecrets))
+	cmd.AddCommand(recoverycontroller.NewCertRecoveryControllerCommand(ctx))
 
 	return cmd
 }

--- a/pkg/cmd/recoverycontroller/cmd.go
+++ b/pkg/cmd/recoverycontroller/cmd.go
@@ -1,0 +1,109 @@
+package recoverycontroller
+
+import (
+	"context"
+	"fmt"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+	"github.com/openshift/cluster-kube-scheduler-operator/pkg/operator/operatorclient"
+	operatorresourcesynccontroller "github.com/openshift/cluster-kube-scheduler-operator/pkg/operator/resourcesynccontroller"
+	"github.com/openshift/library-go/pkg/controller/controllercmd"
+	"github.com/openshift/library-go/pkg/operator/genericoperatorclient"
+	"github.com/openshift/library-go/pkg/operator/resourcesynccontroller"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+	"github.com/spf13/cobra"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/pkg/version"
+)
+
+type Options struct {
+	controllerContext *controllercmd.ControllerContext
+}
+
+func NewCertRecoveryControllerCommand(ctx context.Context) *cobra.Command {
+	o := &Options{}
+
+	ccc := controllercmd.NewControllerCommandConfig("cert-recovery-controller", version.Get(), func(ctx context.Context, controllerContext *controllercmd.ControllerContext) error {
+		o.controllerContext = controllerContext
+
+		err := o.Validate(ctx)
+		if err != nil {
+			return err
+		}
+
+		err = o.Complete(ctx)
+		if err != nil {
+			return err
+		}
+
+		err = o.Run(ctx)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
+
+	// Disable serving for recovery as it introduces a dependency on kube-system::extension-apiserver-authentication
+	// configmap which prevents it to start as the CA bundle is expired.
+	// TODO: Remove when the internal logic can start serving without extension-apiserver-authentication
+	//  	 and live reload extension-apiserver-authentication after it is available
+	ccc.DisableServing = true
+
+	cmd := ccc.NewCommandWithContext(ctx)
+	cmd.Use = "cert-recovery-controller"
+	cmd.Short = "Start the Cluster Certificate Recovery Controller"
+
+	return cmd
+}
+
+func (o *Options) Validate(ctx context.Context) error {
+	return nil
+}
+
+func (o *Options) Complete(ctx context.Context) error {
+	return nil
+}
+
+func (o *Options) Run(ctx context.Context) error {
+	kubeClient, err := kubernetes.NewForConfig(o.controllerContext.ProtoKubeConfig)
+	if err != nil {
+		return fmt.Errorf("can't build kubernetes client: %w", err)
+	}
+
+	kubeInformersForNamespaces := v1helpers.NewKubeInformersForNamespaces(
+		kubeClient,
+		operatorclient.GlobalMachineSpecifiedConfigNamespace,
+		operatorclient.TargetNamespace,
+	)
+
+	operatorClient, dynamicInformers, err := genericoperatorclient.NewStaticPodOperatorClient(o.controllerContext.KubeConfig, operatorv1.GroupVersion.WithResource("kubeschedulers"))
+	if err != nil {
+		return err
+	}
+
+	resourceSyncController := resourcesynccontroller.NewResourceSyncController(
+		operatorClient,
+		kubeInformersForNamespaces,
+		v1helpers.CachedSecretGetter(kubeClient.CoreV1(), kubeInformersForNamespaces),
+		v1helpers.CachedConfigMapGetter(kubeClient.CoreV1(), kubeInformersForNamespaces),
+		o.controllerContext.EventRecorder,
+	)
+	err = operatorresourcesynccontroller.AddSyncClientCertKeySecret(resourceSyncController)
+	if err != nil {
+		return err
+	}
+
+	kubeInformersForNamespaces.Start(ctx.Done())
+	dynamicInformers.Start(ctx.Done())
+
+	// FIXME: These are missing a wait group to track goroutines and handle graceful termination
+	// (@deads2k wants time to think it through)
+	go func() {
+		resourceSyncController.Run(ctx, 1)
+	}()
+
+	<-ctx.Done()
+
+	return nil
+}

--- a/pkg/operator/resourcesynccontroller/resourcesynccontroller.go
+++ b/pkg/operator/resourcesynccontroller/resourcesynccontroller.go
@@ -9,6 +9,19 @@ import (
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 )
 
+func AddSyncClientCertKeySecret(resourceSyncController *resourcesynccontroller.ResourceSyncController) error {
+	return resourceSyncController.SyncSecret(
+		resourcesynccontroller.ResourceLocation{
+			Namespace: operatorclient.TargetNamespace,
+			Name:      "kube-scheduler-client-cert-key",
+		},
+		resourcesynccontroller.ResourceLocation{
+			Namespace: operatorclient.GlobalMachineSpecifiedConfigNamespace,
+			Name:      "kube-scheduler-client-cert-key",
+		},
+	)
+}
+
 func NewResourceSyncController(
 	operatorConfigClient v1helpers.OperatorClient,
 	kubeInformersForNamespaces v1helpers.KubeInformersForNamespaces,
@@ -23,10 +36,7 @@ func NewResourceSyncController(
 		eventRecorder,
 	)
 
-	if err := resourceSyncController.SyncSecret(
-		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.TargetNamespace, Name: "kube-scheduler-client-cert-key"},
-		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.GlobalMachineSpecifiedConfigNamespace, Name: "kube-scheduler-client-cert-key"},
-	); err != nil {
+	if err := AddSyncClientCertKeySecret(resourceSyncController); err != nil {
 		return nil, err
 	}
 	return resourceSyncController, nil

--- a/pkg/operator/v410_00_assets/bindata.go
+++ b/pkg/operator/v410_00_assets/bindata.go
@@ -468,6 +468,30 @@ spec:
         name: resource-dir
       - mountPath: /etc/kubernetes/static-pod-certs
         name: cert-dir
+  - name: kube-scheduler-recovery-controller
+    env:
+    - name: POD_NAMESPACE
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
+    image: ${OPERATOR_IMAGE}
+    imagePullPolicy: IfNotPresent
+    terminationMessagePolicy: FallbackToLogsOnError
+    command: ["/bin/bash", "-euxo", "pipefail", "-c"]
+    args:
+      - |
+        timeout 3m /bin/bash -exuo pipefail -c 'while [ -n "$(ss -Htanop \( sport = 10443 \))" ]; do sleep 1; done'
+
+        exec cluster-kube-scheduler-operator cert-recovery-controller --kubeconfig=/etc/kubernetes/static-pod-resources/configmaps/kube-scheduler-cert-syncer-kubeconfig/kubeconfig  --namespace=${POD_NAMESPACE} --listen=0.0.0.0:10443 -v=2
+    resources:
+      requests:
+        memory: 50Mi
+        cpu: 5m
+    volumeMounts:
+      - mountPath: /etc/kubernetes/static-pod-resources
+        name: resource-dir
+      - mountPath: /etc/kubernetes/static-pod-certs
+        name: cert-dir
   hostNetwork: true
   priorityClassName: system-node-critical
   tolerations:


### PR DESCRIPTION
New client certs are regenerated by `kube-apiserver-regeneration-controller` into `openshift-config-managed` namespace but kube-scheduler is missing a resource sync loop for transferring them to `openshift-kube-scheduler` namespace.

This PR adds a controller to sync that client-cert-key as static pod sidecar.

Workaround for the issue:
```
oc patch secret -n openshift-kube-scheduler kube-scheduler-client-cert-key -p '{"data": {"tls.crt": "'$( oc get secret -n openshift-config-managed kube-scheduler-client-cert-key --template='{{index .data "tls.crt"}}' )'", "tls.key": "'$( oc get secret -n openshift-config-managed kube-scheduler-client-cert-key --template='{{index .data "tls.key"}}' )'"}}'
```

/cc @soltysh 