### PR TITLE
Bug 1889308: Set dnsPolicy ClusterFirstWithHostNet to match hostNetwork

### DIFF
--- a/bindata/bootkube/bootstrap-manifests/kube-scheduler-pod.yaml
+++ b/bindata/bootkube/bootstrap-manifests/kube-scheduler-pod.yaml
@@ -33,6 +33,7 @@ spec:
 
       name: logs
   hostNetwork: true
+  dnsPolicy: ClusterFirstWithHostNet
   volumes:
   - hostPath:
       path: {{ .SecretsHostPath }}

--- a/bindata/v4.1.0/kube-scheduler/pod.yaml
+++ b/bindata/v4.1.0/kube-scheduler/pod.yaml
@@ -88,6 +88,7 @@ spec:
       - mountPath: /etc/kubernetes/static-pod-certs
         name: cert-dir
   hostNetwork: true
+  dnsPolicy: ClusterFirstWithHostNet
   priorityClassName: system-node-critical
   tolerations:
   - operator: "Exists"

--- a/pkg/operator/v410_00_assets/bindata.go
+++ b/pkg/operator/v410_00_assets/bindata.go
@@ -469,6 +469,7 @@ spec:
       - mountPath: /etc/kubernetes/static-pod-certs
         name: cert-dir
   hostNetwork: true
+  dnsPolicy: ClusterFirstWithHostNet
   priorityClassName: system-node-critical
   tolerations:
   - operator: "Exists"


### PR DESCRIPTION
Based on https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy we should always set `dnsPolicy: ClusterFirstWithHostNet` when we have `hostNetwork: true`. 

/assign @damemi 