### PR TITLE
Revert "Set dnsPolicy ClusterFirstWithHostNet to match hostNetwork"

### DIFF
--- a/bindata/bootkube/bootstrap-manifests/kube-scheduler-pod.yaml
+++ b/bindata/bootkube/bootstrap-manifests/kube-scheduler-pod.yaml
@@ -33,7 +33,6 @@ spec:
 
       name: logs
   hostNetwork: true
-  dnsPolicy: ClusterFirstWithHostNet
   volumes:
   - hostPath:
       path: {{ .SecretsHostPath }}

--- a/bindata/v4.1.0/kube-scheduler/pod.yaml
+++ b/bindata/v4.1.0/kube-scheduler/pod.yaml
@@ -88,7 +88,6 @@ spec:
       - mountPath: /etc/kubernetes/static-pod-certs
         name: cert-dir
   hostNetwork: true
-  dnsPolicy: ClusterFirstWithHostNet
   priorityClassName: system-node-critical
   tolerations:
   - operator: "Exists"

--- a/pkg/operator/v410_00_assets/bindata.go
+++ b/pkg/operator/v410_00_assets/bindata.go
@@ -469,7 +469,6 @@ spec:
       - mountPath: /etc/kubernetes/static-pod-certs
         name: cert-dir
   hostNetwork: true
-  dnsPolicy: ClusterFirstWithHostNet
   priorityClassName: system-node-critical
   tolerations:
   - operator: "Exists"


### PR DESCRIPTION
This reverts commit 3ef0d47ec29778ad15c42aef50f33025a44dd0b1 (#293) which is causing that our static pods have in-cluster dns server injected (see https://github.com/kubernetes/kubernetes/blob/442a69c3bdf6fe8e525b05887e57d89db1e2f3a5/pkg/kubelet/network/dns/dns.go#L348-L352), which is problematic during upgrades. I'm talking with the node team how and if this is going to be solved in kubelet. 

/assign @damemi 