### PR TITLE
bug 1889488: Have probes listen to secure ports

### DIFF
--- a/bindata/v4.1.0/kube-scheduler/pod.yaml
+++ b/bindata/v4.1.0/kube-scheduler/pod.yaml
@@ -53,15 +53,15 @@ spec:
       name: cert-dir
     livenessProbe:
       httpGet:
-        scheme: HTTP
-        port: 10251
+        scheme: HTTPS
+        port: 10259
         path: healthz
       initialDelaySeconds: 45
       timeOutSeconds: 10
     readinessProbe:
       httpGet:
-        scheme: HTTP
-        port: 10251
+        scheme: HTTPS
+        port: 10259
         path: healthz
       initialDelaySeconds: 45
       timeOutSeconds: 10

--- a/pkg/operator/v410_00_assets/bindata.go
+++ b/pkg/operator/v410_00_assets/bindata.go
@@ -503,15 +503,15 @@ spec:
       name: cert-dir
     livenessProbe:
       httpGet:
-        scheme: HTTP
-        port: 10251
+        scheme: HTTPS
+        port: 10259
         path: healthz
       initialDelaySeconds: 45
       timeOutSeconds: 10
     readinessProbe:
       httpGet:
-        scheme: HTTP
-        port: 10251
+        scheme: HTTPS
+        port: 10259
         path: healthz
       initialDelaySeconds: 45
       timeOutSeconds: 10


### PR DESCRIPTION
Insecure port 10251 is getting removed in 1.21 in favor of secure port 10259