### PR TITLE
Bug 1891068: manifests: add missing profile annotations

### DIFF
--- a/manifests/0000_90_kube-scheduler-operator_04_servicemonitor-scheduler.yaml
+++ b/manifests/0000_90_kube-scheduler-operator_04_servicemonitor-scheduler.yaml
@@ -2,6 +2,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: prometheus-k8s-scheduler-resources
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 rules:
 - nonResourceURLs:
   - /metrics/resources
@@ -49,6 +52,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: prometheus-k8s-scheduler-resources
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
@smarterclayton @wking @fabiand 

https://github.com/openshift/cluster-kube-scheduler-operator/pull/283 added a resource without profile annotations.

https://github.com/openshift/oc/pull/663 will prevent this from happening again.

In fact, it was the CI run on this PR that caught this
https://storage.googleapis.com/origin-ci-test/pr-logs/pull/openshift_oc/663/pull-ci-openshift-oc-master-images/1349103979241410560/build-log.txt