### PR TITLE
bug 1889488: [e2e]: kube_pod_resource_requests renamed to kube_pod_container_resource_requests

### DIFF
--- a/test/e2e/scheduler_test.go
+++ b/test/e2e/scheduler_test.go
@@ -307,8 +307,8 @@ func TestMetricsAccessible(t *testing.T) {
 		t.Fatalf("error creating route client for prometheus: %v", err)
 	}
 	for _, metric := range []string{
-		"scheduler_schedule_attempts_total", // returned by /metrics
-		"kube_pod_resource_request",         // returned by /metrics/resources
+		"scheduler_schedule_attempts_total",    // returned by /metrics
+		"kube_pod_container_resource_requests", // returned by /metrics/resources
 	} {
 		var response model.Value
 		err = wait.PollImmediate(time.Second*1, time.Minute*3, func() (bool, error) {


### PR DESCRIPTION
Related: https://github.com/openshift/cluster-kube-scheduler-operator/issues/322