### PR TITLE
bug 1920509: Use ss instead of lsof when waiting for ports

### DIFF
--- a/bindata/v4.1.0/kube-scheduler/pod.yaml
+++ b/bindata/v4.1.0/kube-scheduler/pod.yaml
@@ -19,7 +19,7 @@ spec:
     args:
     - |
       echo -n "Waiting for port :10259 and :10251 to be released."
-      while [ -n "$(lsof -ni :10251)" -o -n "$(lsof -i :10259)" ]; do
+      while [ -n "$(ss -Htan '( sport = 10251 or sport = 10259 )')" ]; do
         echo -n "."
         sleep 1
       done

--- a/pkg/operator/v410_00_assets/bindata.go
+++ b/pkg/operator/v410_00_assets/bindata.go
@@ -469,7 +469,7 @@ spec:
     args:
     - |
       echo -n "Waiting for port :10259 and :10251 to be released."
-      while [ -n "$(lsof -ni :10251)" -o -n "$(lsof -i :10259)" ]; do
+      while [ -n "$(ss -Htan '( sport = 10251 or sport = 10259 )')" ]; do
         echo -n "."
         sleep 1
       done


### PR DESCRIPTION
"ss" shows sockets in CLOSE-WAIT state, so it's more accurate.

Following on https://github.com/openshift/cluster-kube-scheduler-operator/pull/252

CC @soltysh 