### PR TITLE
defines test-e2e-preferred-host job for running smoke tests to check if KS talks to Kube over a preferred host

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,11 @@ e2e: GO_TEST_PACKAGES :=./test/e2e
 e2e: test-unit
 .PHONY: e2e
 
+test-e2e-preferred-host: GO_TEST_PACKAGES :=./test/e2e-preferred-host/...
+test-e2e-preferred-host: GO_TEST_FLAGS += -timeout 1h
+test-e2e-preferred-host: test-unit
+.PHONY: test-e2e-preferred-host
+
 clean:
 	$(RM) ./cluster-kube-scheduler-operator
 .PHONY: clean

--- a/test/e2e-preferred-host/ks_preferred_host_kas_test.go
+++ b/test/e2e-preferred-host/ks_preferred_host_kas_test.go
@@ -1,0 +1,7 @@
+package e2e_preferred_host
+
+import "testing"
+
+func TestKSTalksOverPreferredToKas(t *testing.T) {
+	t.Log("implement me")
+}


### PR DESCRIPTION
I'm going to implement it later. For now, I need it as it is to define a new CI job.

The new tests can be run directly from command line `make test-e2e-preferred-host`