### PR TITLE
servicemonitor: Relabel kube_pod_resource_* pod/namespace labels

### DIFF
--- a/manifests/0000_90_kube-scheduler-operator_04_servicemonitor-scheduler.yaml
+++ b/manifests/0000_90_kube-scheduler-operator_04_servicemonitor-scheduler.yaml
@@ -86,6 +86,7 @@ spec:
       caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
       serverName: scheduler.openshift-kube-scheduler.svc
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    honorLabels: true
     interval: 30s
     path: /metrics/resources
     port: https


### PR DESCRIPTION
The tenancy proxy does not allow someone to fetch metrics for pods
unless they are namespace labelled. This is also a usability improvement
for end users.