### PR TITLE
Add management workload annotations

### DIFF
--- a/bindata/bootkube/bootstrap-manifests/kube-scheduler-pod.yaml
+++ b/bindata/bootkube/bootstrap-manifests/kube-scheduler-pod.yaml
@@ -8,6 +8,7 @@ metadata:
     openshift.io/component: "scheduler"
   annotations:
     openshift.io/run-level: "0"
+    workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
 spec:
   containers:
   - name: kube-scheduler

--- a/bindata/bootkube/manifests/00_openshift-kube-scheduler-ns.yaml
+++ b/bindata/bootkube/manifests/00_openshift-kube-scheduler-ns.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   annotations:
     openshift.io/node-selector: ""
+    workload.openshift.io/allowed: "management"
   name: openshift-kube-scheduler
   labels:
     openshift.io/run-level: "0"

--- a/bindata/v4.1.0/kube-scheduler/ns.yaml
+++ b/bindata/v4.1.0/kube-scheduler/ns.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   annotations:
     openshift.io/node-selector: ""
+    workload.openshift.io/allowed: "management"
   name: openshift-kube-scheduler
   labels:
     openshift.io/run-level: "0"

--- a/bindata/v4.1.0/kube-scheduler/pod.yaml
+++ b/bindata/v4.1.0/kube-scheduler/pod.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: openshift-kube-scheduler
   annotations:
     kubectl.kubernetes.io/default-logs-container: kube-scheduler
+    workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
   labels:
     app: openshift-kube-scheduler
     scheduler: "true"

--- a/manifests/0000_25_kube-scheduler-operator_00_namespace.yaml
+++ b/manifests/0000_25_kube-scheduler-operator_00_namespace.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     openshift.io/node-selector: ""
+    workload.openshift.io/allowed: "management"
   labels:
     openshift.io/run-level: "0"
     openshift.io/cluster-monitoring: "true"

--- a/manifests/0000_25_kube-scheduler-operator_06_deployment.yaml
+++ b/manifests/0000_25_kube-scheduler-operator_06_deployment.yaml
@@ -17,6 +17,8 @@ spec:
   template:
     metadata:
       name: openshift-kube-scheduler-operator
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: openshift-kube-scheduler-operator
     spec:

--- a/pkg/operator/targetconfigcontroller/testdata/ks_pod_scenario_1.yaml
+++ b/pkg/operator/targetconfigcontroller/testdata/ks_pod_scenario_1.yaml
@@ -11,6 +11,7 @@ metadata:
     scheduler: 'true'
   annotations:
     kubectl.kubernetes.io/default-logs-container: kube-scheduler
+    workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
 spec:
   volumes:
     - name: resource-dir

--- a/pkg/operator/targetconfigcontroller/testdata/ks_pod_scenario_2.yaml
+++ b/pkg/operator/targetconfigcontroller/testdata/ks_pod_scenario_2.yaml
@@ -11,6 +11,7 @@ metadata:
     scheduler: 'true'
   annotations:
     kubectl.kubernetes.io/default-logs-container: kube-scheduler
+    workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
 spec:
   volumes:
     - name: resource-dir

--- a/pkg/operator/targetconfigcontroller/testdata/ks_pod_scenario_3.yaml
+++ b/pkg/operator/targetconfigcontroller/testdata/ks_pod_scenario_3.yaml
@@ -11,6 +11,7 @@ metadata:
     scheduler: 'true'
   annotations:
     kubectl.kubernetes.io/default-logs-container: kube-scheduler
+    workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
 spec:
   volumes:
     - name: resource-dir

--- a/pkg/operator/v410_00_assets/bindata.go
+++ b/pkg/operator/v410_00_assets/bindata.go
@@ -401,6 +401,7 @@ kind: Namespace
 metadata:
   annotations:
     openshift.io/node-selector: ""
+    workload.openshift.io/allowed: "management"
   name: openshift-kube-scheduler
   labels:
     openshift.io/run-level: "0"
@@ -455,6 +456,7 @@ metadata:
   namespace: openshift-kube-scheduler
   annotations:
     kubectl.kubernetes.io/default-logs-container: kube-scheduler
+    workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
   labels:
     app: openshift-kube-scheduler
     scheduler: "true"


### PR DESCRIPTION
In support of the workload partitioning feature
(https://github.com/openshift/enhancements/pull/703), we need to add
annotations to all management pods and namespaces so they can be
properly identified and assigned to segregated management cores on
clusters configured to do so.