### PR TITLE
Rename workload annotations

### DIFF
--- a/bindata/bootkube/bootstrap-manifests/kube-scheduler-pod.yaml
+++ b/bindata/bootkube/bootstrap-manifests/kube-scheduler-pod.yaml
@@ -8,7 +8,7 @@ metadata:
     openshift.io/component: "scheduler"
   annotations:
     openshift.io/run-level: "0"
-    workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+    target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
 spec:
   containers:
   - name: kube-scheduler

--- a/bindata/v4.1.0/kube-scheduler/pod.yaml
+++ b/bindata/v4.1.0/kube-scheduler/pod.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: openshift-kube-scheduler
   annotations:
     kubectl.kubernetes.io/default-logs-container: kube-scheduler
-    workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+    target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
   labels:
     app: openshift-kube-scheduler
     scheduler: "true"

--- a/manifests/0000_25_kube-scheduler-operator_06_deployment.yaml
+++ b/manifests/0000_25_kube-scheduler-operator_06_deployment.yaml
@@ -18,7 +18,7 @@ spec:
     metadata:
       name: openshift-kube-scheduler-operator
       annotations:
-        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: openshift-kube-scheduler-operator
     spec:

--- a/pkg/operator/targetconfigcontroller/testdata/ks_pod_scenario_1.yaml
+++ b/pkg/operator/targetconfigcontroller/testdata/ks_pod_scenario_1.yaml
@@ -11,7 +11,7 @@ metadata:
     scheduler: 'true'
   annotations:
     kubectl.kubernetes.io/default-logs-container: kube-scheduler
-    workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+    target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
 spec:
   volumes:
     - name: resource-dir

--- a/pkg/operator/targetconfigcontroller/testdata/ks_pod_scenario_2.yaml
+++ b/pkg/operator/targetconfigcontroller/testdata/ks_pod_scenario_2.yaml
@@ -11,7 +11,7 @@ metadata:
     scheduler: 'true'
   annotations:
     kubectl.kubernetes.io/default-logs-container: kube-scheduler
-    workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+    target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
 spec:
   volumes:
     - name: resource-dir

--- a/pkg/operator/targetconfigcontroller/testdata/ks_pod_scenario_3.yaml
+++ b/pkg/operator/targetconfigcontroller/testdata/ks_pod_scenario_3.yaml
@@ -11,7 +11,7 @@ metadata:
     scheduler: 'true'
   annotations:
     kubectl.kubernetes.io/default-logs-container: kube-scheduler
-    workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+    target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
 spec:
   volumes:
     - name: resource-dir

--- a/pkg/operator/v410_00_assets/bindata.go
+++ b/pkg/operator/v410_00_assets/bindata.go
@@ -456,7 +456,7 @@ metadata:
   namespace: openshift-kube-scheduler
   annotations:
     kubectl.kubernetes.io/default-logs-container: kube-scheduler
-    workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+    target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
   labels:
     app: openshift-kube-scheduler
     scheduler: "true"


### PR DESCRIPTION
As per https://github.com/openshift/enhancements/pull/739, the workload
annotations names are changing.

Signed-off-by: Jim Ramsay <jramsay@redhat.com>

/hold
Hold until after openshift/kubernetes#632 is merged please