### PR TITLE
Bug 1963730: kube-apiserver failed to load SNI cert and key

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/openshift/api v0.0.0-20210521075222-e273a339932a
 	github.com/openshift/build-machinery-go v0.0.0-20210423112049-9415d7ebd33e
 	github.com/openshift/client-go v0.0.0-20210521082421-73d9475a9142
-	github.com/openshift/library-go v0.0.0-20210609150209-1c980926414c
+	github.com/openshift/library-go v0.0.0-20210611094144-35c8a075e255
 	github.com/prometheus/client_golang v1.7.1
 	github.com/prometheus/common v0.10.0
 	github.com/spf13/cobra v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -405,8 +405,8 @@ github.com/openshift/client-go v0.0.0-20210521082421-73d9475a9142 h1:ZHRIMCFIJN1
 github.com/openshift/client-go v0.0.0-20210521082421-73d9475a9142/go.mod h1:fjS8r9mqDVsPb5td3NehsNOAWa4uiFkYEfVZioQ2gH0=
 github.com/openshift/kubernetes-apiserver v0.0.0-20210419140141-620426e63a99 h1:KrCYRAJcgZYzMCB1PjJHJMYPu/d+dEkelq5eYyi0fDw=
 github.com/openshift/kubernetes-apiserver v0.0.0-20210419140141-620426e63a99/go.mod h1:w2YSn4/WIwYuxG5zJmcqtRdtqgW/J2JRgFAqps3bBpg=
-github.com/openshift/library-go v0.0.0-20210609150209-1c980926414c h1:1U/zY54WyRyEsVoAHf6yLDgSHf5famdKnIBulyGOLGU=
-github.com/openshift/library-go v0.0.0-20210609150209-1c980926414c/go.mod h1:C5DDOSPucn3EVA0T05fODKtAweTObMBrTYm/G3uUBI8=
+github.com/openshift/library-go v0.0.0-20210611094144-35c8a075e255 h1:4lXXCXSNmAD56T+lL0CRQfm4aImnb1I6Va9QVtN/d+Q=
+github.com/openshift/library-go v0.0.0-20210611094144-35c8a075e255/go.mod h1:C5DDOSPucn3EVA0T05fODKtAweTObMBrTYm/G3uUBI8=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/certsyncpod/certsync_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/certsyncpod/certsync_controller.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/staticpod"
 	"github.com/openshift/library-go/pkg/operator/staticpod/controller/installer"
 )
 
@@ -157,7 +158,7 @@ func (c *CertSyncController) sync(ctx context.Context, syncCtx factory.SyncConte
 			}
 
 			klog.Infof("Writing configmap manifest %q ...", fullFilename)
-			if err := ioutil.WriteFile(fullFilename, []byte(content), 0644); err != nil {
+			if err := staticpod.WriteFileAtomic([]byte(content), 0644, fullFilename); err != nil {
 				c.eventRecorder.Warningf("CertificateUpdateFailed", "Failed writing file for configmap: %s/%s: %v", configMap.Namespace, configMap.Name, err)
 				errors = append(errors, err)
 				continue
@@ -263,7 +264,7 @@ func (c *CertSyncController) sync(ctx context.Context, syncCtx factory.SyncConte
 			}
 
 			klog.Infof("Writing secret manifest %q ...", fullFilename)
-			if err := ioutil.WriteFile(fullFilename, content, 0644); err != nil {
+			if err := staticpod.WriteFileAtomic(content, 0644, fullFilename); err != nil {
 				c.eventRecorder.Warningf("CertificateUpdateFailed", "Failed writing file for secret: %s/%s: %v", secret.Namespace, secret.Name, err)
 				errors = append(errors, err)
 				continue

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/prune/prune_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/prune/prune_controller.go
@@ -28,7 +28,7 @@ import (
 // PruneController is a controller that watches static installer pod revision statuses and spawns
 // a pruner pod to delete old revision resources from disk
 type PruneController struct {
-	targetNamespace, podResourcePrefix string
+	targetNamespace, podResourcePrefix, certDir string
 	// command is the string to use for the pruning pod command
 	command []string
 
@@ -57,6 +57,7 @@ const (
 func NewPruneController(
 	targetNamespace string,
 	podResourcePrefix string,
+	certDir string,
 	command []string,
 	configMapGetter corev1client.ConfigMapsGetter,
 	secretGetter corev1client.SecretsGetter,
@@ -67,6 +68,7 @@ func NewPruneController(
 	c := &PruneController{
 		targetNamespace:   targetNamespace,
 		podResourcePrefix: podResourcePrefix,
+		certDir:           certDir,
 		command:           command,
 
 		operatorClient:  operatorClient,
@@ -225,6 +227,7 @@ func (c *PruneController) ensurePrunePod(recorder events.Recorder, nodeName stri
 		fmt.Sprintf("--max-eligible-revision=%d", maxEligibleRevision),
 		fmt.Sprintf("--protected-revisions=%s", revisionsToString(protectedRevisions)),
 		fmt.Sprintf("--resource-dir=%s", "/etc/kubernetes/static-pod-resources"),
+		fmt.Sprintf("--cert-dir=%s", c.certDir),
 		fmt.Sprintf("--static-pod-name=%s", c.podResourcePrefix),
 	)
 

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controllers.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controllers.go
@@ -230,6 +230,7 @@ func (b *staticPodOperatorControllerBuilder) ToControllers() (manager.Controller
 		manager.WithController(prune.NewPruneController(
 			b.operandNamespace,
 			b.staticPodPrefix,
+			b.certDir,
 			b.pruneCommand,
 			configMapClient,
 			secretClient,

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/file_utils.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/file_utils.go
@@ -1,0 +1,35 @@
+package staticpod
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"io/ioutil"
+)
+
+func WriteFileAtomic(content []byte, filePerms os.FileMode, fullFilename string) error {
+	tmpFile, err := writeTemporaryFile(content, filePerms, fullFilename)
+	if err != nil {
+		return err
+	}
+
+	return os.Rename(tmpFile, fullFilename)
+}
+
+func writeTemporaryFile(content []byte, filePerms os.FileMode, fullFilename string) (string, error) {
+	contentDir := filepath.Dir(fullFilename)
+	filename := filepath.Base(fullFilename)
+	tmpfile, err := ioutil.TempFile(contentDir, fmt.Sprintf("%s.tmp", filename))
+	if err != nil {
+		return "", err
+	}
+	defer tmpfile.Close()
+	if err := tmpfile.Chmod(filePerms); err != nil {
+		return "", err
+	}
+	if _, err := tmpfile.Write(content); err != nil {
+		return "", err
+	}
+	return tmpfile.Name(), nil
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/prune/cmd.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/prune/cmd.go
@@ -5,8 +5,10 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/spf13/cobra"
@@ -21,6 +23,7 @@ type PruneOptions struct {
 	ProtectedRevisions  []int
 
 	ResourceDir   string
+	CertDir       string
 	StaticPodName string
 }
 
@@ -57,6 +60,7 @@ func (o *PruneOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.IntSliceVar(&o.ProtectedRevisions, "protected-revisions", o.ProtectedRevisions, "list of revision IDs to preserve (not delete)")
 	fs.StringVar(&o.ResourceDir, "resource-dir", o.ResourceDir, "directory for all files supporting the static pod manifest")
 	fs.StringVar(&o.StaticPodName, "static-pod-name", o.StaticPodName, "name of the static pod")
+	fs.StringVar(&o.CertDir, "cert-dir", o.CertDir, "directory for all certs")
 }
 
 func (o *PruneOptions) Validate() error {
@@ -112,5 +116,37 @@ func (o *PruneOptions) Run() error {
 			return err
 		}
 	}
-	return nil
+
+	// prune any temporary certificate files
+	// we do create temporary files to atomically "write" various certificates to disk
+	// usually, these files are short-lived because they are immediately renamed, the following loop removes old/unused/dangling files
+	//
+	// the temporary files have the following form:
+	//  /etc/kubernetes/static-pod-resources/kube-apiserver-certs/configmaps/control-plane-node-kubeconfig/kubeconfig.tmp753375784
+	//  /etc/kubernetes/static-pod-resources/kube-apiserver-certs/secrets/service-network-serving-certkey/tls.key.tmp643092404
+	if len(o.CertDir) == 0 {
+		return nil
+	}
+
+	return filepath.Walk(path.Join(o.ResourceDir, o.CertDir),
+		func(filePath string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			if info.IsDir() {
+				return nil
+			}
+			// info.Name() gives just a filename like tls.key or tls.key.tmp643092404
+			if !strings.Contains(info.Name(), ".tmp") {
+				return nil
+			}
+			if time.Now().Sub(info.ModTime()) > 30*time.Minute {
+				klog.Infof("Removing %s, the last time it was modified was %v", filePath, info.ModTime())
+				if err := os.RemoveAll(filePath); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+	)
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -179,7 +179,7 @@ github.com/openshift/client-go/operator/clientset/versioned/typed/operator/v1alp
 github.com/openshift/client-go/route/clientset/versioned
 github.com/openshift/client-go/route/clientset/versioned/scheme
 github.com/openshift/client-go/route/clientset/versioned/typed/route/v1
-# github.com/openshift/library-go v0.0.0-20210609150209-1c980926414c
+# github.com/openshift/library-go v0.0.0-20210611094144-35c8a075e255
 ## explicit
 github.com/openshift/library-go/pkg/assets
 github.com/openshift/library-go/pkg/authorization/hardcodedauthorizer


### PR DESCRIPTION
As of today, the dynamic certificates i.e. `kube-apiserver-certs` are accessed by at least two processes, namely the installer pod and the cert-syncer.
Up until now, there was no coordination between these processes that might have lead to many unexpected errors, like https://bugzilla.redhat.com/show_bug.cgi?id=1963730

This PR writes all certificates in an atomic way by first creating a temporary file, writing the content to it, and then renaming it to the original file. 

`os.Rename` calls `syscall.Rename` which in turn uses the rename syscall (Linux) which provides atomicity (https://man7.org/linux/man-pages/man2/rename.2.html)


The previous attempt didn't work as it would break the DR scripts - https://github.com/openshift/library-go/pull/1098