### PR TITLE
Fire SchedulerLegacyPolicySet alert when the legacy scheduler policy API is set

### DIFF
--- a/manifests/0000_90_kube-scheduler-operator_03_servicemonitor.yaml
+++ b/manifests/0000_90_kube-scheduler-operator_03_servicemonitor.yaml
@@ -50,3 +50,12 @@ spec:
       for: 15m
       labels:
         severity: critical
+  - name: scheduler-legacy-policy-deprecated
+    rules:
+    - alert: SchedulerLegacyPolicySet
+      annotations:
+        message: The scheduler is currently configured to use a legacy scheduler policy API. Use of the policy API is deprecated and removed in 4.10.
+      expr: |
+        cluster_legacy_scheduler_policy > 0
+      labels:
+        severity: warning


### PR DESCRIPTION
Alert users about usage of deprecated scheduler policy API and its removal in 4.10

https://issues.redhat.com/browse/WRKLDS-316