### PR TITLE
Bug 1984608: Set kube-scheduler leader election defaults

### DIFF
--- a/bindata/assets/config/defaultconfig-postbootstrap-highnodeutilization.yaml
+++ b/bindata/assets/config/defaultconfig-postbootstrap-highnodeutilization.yaml
@@ -1,11 +1,5 @@
 apiVersion: kubescheduler.config.k8s.io/v1beta1
 kind: KubeSchedulerConfiguration
-clientConnection:
-  kubeconfig: /etc/kubernetes/static-pod-resources/configmaps/scheduler-kubeconfig/kubeconfig
-leaderElection:
-  leaderElect: true
-  resourceNamespace: "openshift-kube-scheduler"
-  resourceLock: "configmaps"
 profiles:
   - schedulerName: default-scheduler
     plugins:

--- a/bindata/assets/config/defaultconfig-postbootstrap-lownodeutilization.yaml
+++ b/bindata/assets/config/defaultconfig-postbootstrap-lownodeutilization.yaml
@@ -1,8 +1,2 @@
 apiVersion: kubescheduler.config.k8s.io/v1beta1
 kind: KubeSchedulerConfiguration
-clientConnection:
-  kubeconfig: /etc/kubernetes/static-pod-resources/configmaps/scheduler-kubeconfig/kubeconfig
-leaderElection:
-  leaderElect: true
-  resourceNamespace: "openshift-kube-scheduler"
-  resourceLock: "configmaps"

--- a/bindata/assets/config/defaultconfig-postbootstrap-noscoring.yaml
+++ b/bindata/assets/config/defaultconfig-postbootstrap-noscoring.yaml
@@ -1,11 +1,5 @@
 apiVersion: kubescheduler.config.k8s.io/v1beta1
 kind: KubeSchedulerConfiguration
-clientConnection:
-  kubeconfig: /etc/kubernetes/static-pod-resources/configmaps/scheduler-kubeconfig/kubeconfig
-leaderElection:
-  leaderElect: true
-  resourceNamespace: "openshift-kube-scheduler"
-  resourceLock: "configmaps"
 profiles:
   - schedulerName: default-scheduler
     plugins:

--- a/bindata/assets/config/defaultconfig.yaml
+++ b/bindata/assets/config/defaultconfig.yaml
@@ -1,2 +1,11 @@
 apiVersion: kubescheduler.config.k8s.io/v1beta1
 kind: KubeSchedulerConfiguration
+clientConnection:
+  kubeconfig: /etc/kubernetes/static-pod-resources/configmaps/scheduler-kubeconfig/kubeconfig
+leaderElection:
+  leaseDuration: "137s"
+  renewDeadline: "107s"
+  retryPeriod: "26s"
+  leaderElect: true
+  resourceNamespace: "openshift-kube-scheduler"
+  resourceLock: "configmaps"

--- a/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
+++ b/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
@@ -190,7 +190,8 @@ func manageKubeSchedulerConfigMap_v311_00_to_latest(ctx context.Context, client 
 		}
 	}
 
-	requiredConfigMap, _, err := resourcemerge.MergeConfigMap(configMap, "config.yaml", nil, kubeSchedulerConfiguration)
+	defaultConfig := bindata.MustAsset("assets/config/defaultconfig.yaml")
+	requiredConfigMap, _, err := resourcemerge.MergeConfigMap(configMap, "config.yaml", nil, kubeSchedulerConfiguration, defaultConfig)
 	if err != nil {
 		return nil, false, err
 	}


### PR DESCRIPTION
This sets default LeaderElection values to better handle API server disruption as recommended in https://github.com/openshift/enhancements/blob/master/CONVENTIONS.md#handling-kube-apiserver-disruption