### PR TITLE
Bug 2002300: Disable balancedAllocation and add weight for HighNodeUtilization profile

### DIFF
--- a/bindata/assets/config/defaultconfig-postbootstrap-highnodeutilization.yaml
+++ b/bindata/assets/config/defaultconfig-postbootstrap-highnodeutilization.yaml
@@ -6,5 +6,7 @@ profiles:
       score:
         disabled:
         - name: "NodeResourcesLeastAllocated"
+        - name: "NodeResourcesBalancedAllocation"
         enabled:
         - name: "NodeResourcesMostAllocated"
+          weight: 5


### PR DESCRIPTION
This will likely need to be backported

This profile disables `LeastAllocated` but it does not disable `BalancedAllocation`. It also is setting `MostAllocated` with a weight of `0` (see https://bugzilla.redhat.com/show_bug.cgi?id=2002300#c4)