### PR TITLE
[release-4.9] Bug 2026109: Disable balancedAllocation and add weight for HighNodeUtilization profile

### DIFF
--- a/bindata/assets/config/defaultconfig-postbootstrap-highnodeutilization.yaml
+++ b/bindata/assets/config/defaultconfig-postbootstrap-highnodeutilization.yaml
@@ -6,5 +6,7 @@ profiles:
       score:
         disabled:
         - name: "NodeResourcesLeastAllocated"
+        - name: "NodeResourcesBalancedAllocation"
         enabled:
         - name: "NodeResourcesMostAllocated"
+          weight: 5


### PR DESCRIPTION
backport of https://github.com/openshift/cluster-kube-scheduler-operator/pull/378