### PR TITLE
[release-4.8] Bug 2026110: Disable balancedAllocation and add weight for HighNodeUtilization profile

### DIFF
--- a/bindata/v4.1.0/config/defaultconfig-postbootstrap-highnodeutilization.yaml
+++ b/bindata/v4.1.0/config/defaultconfig-postbootstrap-highnodeutilization.yaml
@@ -12,5 +12,7 @@ profiles:
       score:
         disabled:
         - name: "NodeResourcesLeastAllocated"
+        - name: "NodeResourcesBalancedAllocation"
         enabled:
         - name: "NodeResourcesMostAllocated"
+          weight: 5

--- a/pkg/operator/v410_00_assets/bindata.go
+++ b/pkg/operator/v410_00_assets/bindata.go
@@ -86,8 +86,10 @@ profiles:
       score:
         disabled:
         - name: "NodeResourcesLeastAllocated"
+        - name: "NodeResourcesBalancedAllocation"
         enabled:
         - name: "NodeResourcesMostAllocated"
+          weight: 5
 `)
 
 func v410ConfigDefaultconfigPostbootstrapHighnodeutilizationYamlBytes() ([]byte, error) {


### PR DESCRIPTION
Backport of https://github.com/openshift/cluster-kube-scheduler-operator/pull/378