### PR TITLE
bug 2035927: Replace NodeResourcesLeastAllocated/NodeResourcesMostAllocated plugins with NodeResourcesFit

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,11 @@ metadata:
 
 ### HighNodeUtilization
 
-This profiles disables `NodeResourcesLeastAllocated` plugin and enables `NodeResourcesMostAllocated` plugin.
+This profile disables `NodeResourcesBalancedAllocation` and `NodeResourcesFit` plugin with (`LeastAllocated` type)
+and enables `NodeResourcesFit` plugin (with `MostAllocated` type).
 Favoring nodes that have a high allocation of resources.
+In the past the profile corresponded to disabling `NodeResourcesLeastAllocated` and `NodeResourcesBalancedAllocation` plugins
+and enabling `NodeResourcesMostAllocated` plugin.
 
 ### LowNodeUtilization
 

--- a/bindata/assets/config/defaultconfig-postbootstrap-highnodeutilization.yaml
+++ b/bindata/assets/config/defaultconfig-postbootstrap-highnodeutilization.yaml
@@ -2,11 +2,15 @@ apiVersion: kubescheduler.config.k8s.io/v1beta2
 kind: KubeSchedulerConfiguration
 profiles:
   - schedulerName: default-scheduler
+    pluginConfig:
+      - args:
+          scoringStrategy:
+            type: MostAllocated
+        name: NodeResourcesFit
     plugins:
       score:
         disabled:
-        - name: "NodeResourcesLeastAllocated"
         - name: "NodeResourcesBalancedAllocation"
         enabled:
-        - name: "NodeResourcesMostAllocated"
+        - name: "NodeResourcesFit"
           weight: 5


### PR DESCRIPTION
Based on https://kubernetes.io/docs/reference/scheduling/config/#scheduler-configuration-migrations
and https://github.com/kubernetes/enhancements/tree/master/keps/sig-scheduling/2458-node-resource-score-strategy#summary
both NodeResourcesLeastAllocated and NodeResourcesMostAllocated plugins
were removed from v1beta2 and replaced with NodeResourcesFit.