### PR TITLE
Bug 2039414: Update KubeSchedulerConfig to v1beta3(default in 1.23)

### DIFF
--- a/bindata/assets/config/defaultconfig-postbootstrap-highnodeutilization.yaml
+++ b/bindata/assets/config/defaultconfig-postbootstrap-highnodeutilization.yaml
@@ -1,4 +1,4 @@
-apiVersion: kubescheduler.config.k8s.io/v1beta2
+apiVersion: kubescheduler.config.k8s.io/v1beta3
 kind: KubeSchedulerConfiguration
 profiles:
   - schedulerName: default-scheduler

--- a/bindata/assets/config/defaultconfig-postbootstrap-lownodeutilization.yaml
+++ b/bindata/assets/config/defaultconfig-postbootstrap-lownodeutilization.yaml
@@ -1,2 +1,2 @@
-apiVersion: kubescheduler.config.k8s.io/v1beta2
+apiVersion: kubescheduler.config.k8s.io/v1beta3
 kind: KubeSchedulerConfiguration

--- a/bindata/assets/config/defaultconfig-postbootstrap-noscoring.yaml
+++ b/bindata/assets/config/defaultconfig-postbootstrap-noscoring.yaml
@@ -1,4 +1,4 @@
-apiVersion: kubescheduler.config.k8s.io/v1beta2
+apiVersion: kubescheduler.config.k8s.io/v1beta3
 kind: KubeSchedulerConfiguration
 profiles:
   - schedulerName: default-scheduler

--- a/bindata/assets/config/defaultconfig.yaml
+++ b/bindata/assets/config/defaultconfig.yaml
@@ -1,4 +1,4 @@
-apiVersion: kubescheduler.config.k8s.io/v1beta2
+apiVersion: kubescheduler.config.k8s.io/v1beta3
 kind: KubeSchedulerConfiguration
 clientConnection:
   kubeconfig: /etc/kubernetes/static-pod-resources/configmaps/scheduler-kubeconfig/kubeconfig

--- a/bindata/bootkube/config/bootstrap-config-overrides.yaml
+++ b/bindata/bootkube/config/bootstrap-config-overrides.yaml
@@ -1,2 +1,2 @@
-apiVersion: kubescheduler.config.k8s.io/v1beta2
+apiVersion: kubescheduler.config.k8s.io/v1beta3
 kind: KubeSchedulerConfiguration


### PR DESCRIPTION
Bumping to kubeSchedulerConfig v1beta3 api which is default in kube1.23

cc @damemi @ingvagabund 