### PR TITLE
bug 2037665: Remove policy upgradeable when policy field cleared

### DIFF
--- a/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
+++ b/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
@@ -167,6 +167,11 @@ func createTargetConfigController_v311_00_to_latest(ctx context.Context, syncCtx
 			Reason:  "PolicyFieldSpecified",
 			Message: fmt.Sprintf("deprecated scheduler.policy field is set, and it is to be removed in the next release"),
 		}))
+	} else {
+		updateStatusFuncs = append(updateStatusFuncs, func(oldStatus *operatorv1.StaticPodOperatorStatus) error {
+			v1helpers.RemoveOperatorCondition(&oldStatus.Conditions, "PolicyUpgradeable")
+			return nil
+		})
 	}
 	if _, _, err := v1helpers.UpdateStaticPodStatus(c.operatorClient, updateStatusFuncs...); err != nil {
 		return true, err

--- a/pkg/operator/targetconfigcontroller/targetconfigcontroller_test.go
+++ b/pkg/operator/targetconfigcontroller/targetconfigcontroller_test.go
@@ -491,16 +491,36 @@ func TestPolicyUpgradeable(t *testing.T) {
 		name         string
 		policyCMName string
 		upgradable   bool
+		status       *operatorv1.StaticPodOperatorStatus
 	}{
 		{
 			name:         "PolicyUpgradeable is true",
 			policyCMName: "",
 			upgradable:   true,
+			status:       &operatorv1.StaticPodOperatorStatus{},
 		},
 		{
 			name:         "PolicyUpgradeable is false",
 			policyCMName: "custompolicy",
 			upgradable:   false,
+			status:       &operatorv1.StaticPodOperatorStatus{},
+		},
+		{
+			name:         "PolicyUpgradeable is cleared",
+			policyCMName: "",
+			upgradable:   true,
+			status: &operatorv1.StaticPodOperatorStatus{
+				OperatorStatus: operatorv1.OperatorStatus{
+					Conditions: []operatorv1.OperatorCondition{
+						{
+							Type:    "PolicyUpgradeable",
+							Status:  operatorv1.ConditionFalse,
+							Reason:  "PolicyFieldSpecified",
+							Message: fmt.Sprintf("deprecated scheduler.policy field is set, and it is to be removed in the next release"),
+						},
+					},
+				},
+			},
 		},
 	}
 
@@ -575,7 +595,7 @@ func TestPolicyUpgradeable(t *testing.T) {
 						ManagementState: operatorv1.Managed,
 					},
 				},
-				&operatorv1.StaticPodOperatorStatus{},
+				test.status,
 				nil,
 				nil,
 			)


### PR DESCRIPTION
Extending https://github.com/openshift/cluster-kube-scheduler-operator/pull/400 to remove the `PolicyUpgradeable` condition when the policy name field was previously set but cleared later on.