### PR TITLE
bug 2037665: Check policy name field independently of the configmap change

### DIFF
--- a/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
+++ b/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
@@ -317,9 +317,9 @@ func managePod_v311_00_to_latest(ctx context.Context, configMapsGetter corev1cli
 	configMap.Data["version"] = version.Get().String()
 	appliedConfigMap, changed, err := resourceapply.ApplyConfigMap(ctx, configMapsGetter, recorder, configMap)
 	deprecatedPolicy := false
-	if changed && len(config.Spec.Policy.Name) > 0 {
+	if len(config.Spec.Policy.Name) > 0 {
 		deprecatedPolicy = true
-		klog.Warning("Setting .spec.policy is deprecated and will be removed eventually. Please use .spec.profile instead.")
+		klog.V(3).Infof("Setting .spec.policy is deprecated and will be removed eventually. Please use .spec.profile instead.")
 	}
 	return appliedConfigMap, changed, deprecatedPolicy, err
 }


### PR DESCRIPTION
From the logs:
```
I0125 06:13:50.166765       1 status_controller.go:211] clusteroperator/kube-scheduler diff {"status":{"conditions":[{"lastTransitionTime":"2022-01-25T05:43:31Z","message":"NodeControllerDegraded: All master nodes are ready","reason":"AsExpected","status":"False","type":"Degraded"},{"lastTransitionTime":"2022-01-25T06:13:50Z","message":"NodeInstallerProgressing: 3 nodes are at revision 8; 0 nodes have achieved new revision 9","reason":"NodeInstaller","status":"True","type":"Progressing"},{"lastTransitionTime":"2022-01-25T05:45:45Z","message":"StaticPodsAvailable: 3 nodes are active; 3 nodes are at revision 8; 0 nodes have achieved new revision 9","reason":"AsExpected","status":"True","type":"Available"},{"lastTransitionTime":"2022-01-25T06:13:42Z","message":"PolicyUpgradeable: deprecated scheduler.policy field is set, and it is to be removed in the next release","reason":"Policy_PolicyFieldSpecified","status":"False","type":"Upgradeable"}]}}
...
I0125 06:13:50.953915       1 event.go:282] Event(v1.ObjectReference{Kind:"Deployment", Namespace:"openshift-kube-scheduler-operator", Name:"openshift-kube-scheduler-operator", UID:"825f8035-2ba7-4136-bb5a-88d64e25298e", APIVersion:"apps/v1", ResourceVersion:"", FieldPath:""}): type: 'Normal' reason: 'ConfigMapCreated' Created ConfigMap/config-10 -n openshift-kube-scheduler because it was missing
I0125 06:13:51.366266       1 status_controller.go:211] clusteroperator/kube-scheduler diff {"status":{"conditions":[{"lastTransitionTime":"2022-01-25T05:43:31Z","message":"NodeControllerDegraded: All master nodes are ready","reason":"AsExpected","status":"False","type":"Degraded"},{"lastTransitionTime":"2022-01-25T06:13:50Z","message":"NodeInstallerProgressing: 3 nodes are at revision 8; 0 nodes have achieved new revision 9","reason":"NodeInstaller","status":"True","type":"Progressing"},{"lastTransitionTime":"2022-01-25T05:45:45Z","message":"StaticPodsAvailable: 3 nodes are active; 3 nodes are at revision 8; 0 nodes have achieved new revision 9","reason":"AsExpected","status":"True","type":"Available"},{"lastTransitionTime":"2022-01-25T06:13:51Z","message":"All is well","reason":"AsExpected","status":"True","type":"Upgradeable"}]}}
```

The current deprecatedPolicy condition depends on whether the kube-scheduler-pod CM was updated or not.
Which is unrelated to whether the policy.name field is set or not.
Causing the PolicyUpgradeable condition to be cleared (deprecatedPolicy
to be unset) when the CM is not updated.