### PR TITLE
Do not wait for a port which is no longer used by the scheduler

### DIFF
--- a/bindata/assets/kube-scheduler/pod.yaml
+++ b/bindata/assets/kube-scheduler/pod.yaml
@@ -19,8 +19,8 @@ spec:
     command: ['/usr/bin/timeout', '30', '/bin/bash', '-c']
     args:
     - |
-      echo -n "Waiting for port :10259 and :10251 to be released."
-      while [ -n "$(ss -Htan '( sport = 10251 or sport = 10259 )')" ]; do
+      echo -n "Waiting for port :10259 to be released."
+      while [ -n "$(ss -Htan '( sport = 10259 )')" ]; do
         echo -n "."
         sleep 1
       done

--- a/pkg/operator/targetconfigcontroller/testdata/ks_pod_scenario_1.yaml
+++ b/pkg/operator/targetconfigcontroller/testdata/ks_pod_scenario_1.yaml
@@ -30,8 +30,8 @@ spec:
         - "-c"
       args:
         - |
-          echo -n "Waiting for port :10259 and :10251 to be released."
-          while [ -n "$(ss -Htan '( sport = 10251 or sport = 10259 )')" ]; do
+          echo -n "Waiting for port :10259 to be released."
+          while [ -n "$(ss -Htan '( sport = 10259 )')" ]; do
             echo -n "."
             sleep 1
           done

--- a/pkg/operator/targetconfigcontroller/testdata/ks_pod_scenario_2.yaml
+++ b/pkg/operator/targetconfigcontroller/testdata/ks_pod_scenario_2.yaml
@@ -30,8 +30,8 @@ spec:
         - "-c"
       args:
         - |
-          echo -n "Waiting for port :10259 and :10251 to be released."
-          while [ -n "$(ss -Htan '( sport = 10251 or sport = 10259 )')" ]; do
+          echo -n "Waiting for port :10259 to be released."
+          while [ -n "$(ss -Htan '( sport = 10259 )')" ]; do
             echo -n "."
             sleep 1
           done

--- a/pkg/operator/targetconfigcontroller/testdata/ks_pod_scenario_3.yaml
+++ b/pkg/operator/targetconfigcontroller/testdata/ks_pod_scenario_3.yaml
@@ -30,8 +30,8 @@ spec:
         - "-c"
       args:
         - |
-          echo -n "Waiting for port :10259 and :10251 to be released."
-          while [ -n "$(ss -Htan '( sport = 10251 or sport = 10259 )')" ]; do
+          echo -n "Waiting for port :10259 to be released."
+          while [ -n "$(ss -Htan '( sport = 10259 )')" ]; do
             echo -n "."
             sleep 1
           done


### PR DESCRIPTION
The insecure port 10251 was removed from the kube-scheduler codebase.