### PR TITLE
Update resourcelock to configmapleases

### DIFF
--- a/bindata/assets/config/defaultconfig.yaml
+++ b/bindata/assets/config/defaultconfig.yaml
@@ -8,4 +8,4 @@ leaderElection:
   retryPeriod: "26s"
   leaderElect: true
   resourceNamespace: "openshift-kube-scheduler"
-  resourceLock: "configmaps"
+  resourceLock: "configmapsleases"


### PR DESCRIPTION
This commit ensures that the configmapleases are used for acquiring locks