### PR TITLE
Bug 2053268: Track static pod lifecycle

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/openshift/api v0.0.0-20220121101128-0a830aea20c2
 	github.com/openshift/build-machinery-go v0.0.0-20211213093930-7e33a7eb4ce3
 	github.com/openshift/client-go v0.0.0-20211209144617-7385dd6338e3
-	github.com/openshift/library-go v0.0.0-20220214211841-cd0b0153d75a
+	github.com/openshift/library-go v0.0.0-20220215155240-bb7a5da7adb6
 	github.com/prometheus/client_golang v1.11.0
 	github.com/prometheus/common v0.28.0
 	github.com/spf13/cobra v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -514,8 +514,8 @@ github.com/openshift/build-machinery-go v0.0.0-20211213093930-7e33a7eb4ce3 h1:65
 github.com/openshift/build-machinery-go v0.0.0-20211213093930-7e33a7eb4ce3/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20211209144617-7385dd6338e3 h1:SG1aqwleU6bGD0X4mhkTNupjVnByMYYuW4XbnCPavQU=
 github.com/openshift/client-go v0.0.0-20211209144617-7385dd6338e3/go.mod h1:cwhyki5lqBmrT0m8Im+9I7PGFaraOzcYPtEz93RcsGY=
-github.com/openshift/library-go v0.0.0-20220214211841-cd0b0153d75a h1:xvsMDKK13hCY5Qk3PEQJSPbNyn3Y7MDrIfqAMA/nshs=
-github.com/openshift/library-go v0.0.0-20220214211841-cd0b0153d75a/go.mod h1:6AmNM4N4nHftckybV/U7bQW+5AvK5TW81ndSI6KEidw=
+github.com/openshift/library-go v0.0.0-20220215155240-bb7a5da7adb6 h1:YTvnL69xtm0ffq9njtw1P8Dl1CHhZhJCd464pTXQ40M=
+github.com/openshift/library-go v0.0.0-20220215155240-bb7a5da7adb6/go.mod h1:6AmNM4N4nHftckybV/U7bQW+5AvK5TW81ndSI6KEidw=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controllers.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controllers.go
@@ -351,6 +351,7 @@ func (b *staticPodOperatorControllerBuilder) ToControllers() (manager.Controller
 		b.kubeInformers.InformersFor(b.operandNamespace),
 		b.eventRecorder,
 		b.operandNamespace,
+		b.staticPodName,
 		b.operandName,
 	), 1)
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -221,7 +221,7 @@ github.com/openshift/client-go/operator/clientset/versioned/typed/operator/v1alp
 github.com/openshift/client-go/route/clientset/versioned
 github.com/openshift/client-go/route/clientset/versioned/scheme
 github.com/openshift/client-go/route/clientset/versioned/typed/route/v1
-# github.com/openshift/library-go v0.0.0-20220214211841-cd0b0153d75a
+# github.com/openshift/library-go v0.0.0-20220215155240-bb7a5da7adb6
 ## explicit; go 1.17
 github.com/openshift/library-go/pkg/assets
 github.com/openshift/library-go/pkg/authorization/hardcodedauthorizer


### PR DESCRIPTION
1.  If the Bugzilla associated with the PR has the "FastFix" keyword, the subjective assessment on the issue has already been done and a customer is impacted. These PRs should be prioritized for merge.
    - [ ] verified
    - [x] does not apply
2. The bug has significant impact either through severity, reduction in supportability, or number of users affected.
    - [x] verified
    - [ ] does not apply
3. For branches that are in the Maintenance lifecycle phase:
    - [ ] The bug is a critical fix, no reasonable workaround exists, and a recommendation for upgrade has been ruled out, or 
    - [ ] The bug is a security related bug
    - [x] Branch not in maintenance mode yet (current release + previous release for 90 days after current GA; everything older is in maintenance)
4. The severity field of the bug must be set to accurately reflect criticality.
    - [x] verified
5. The PR was created with the cherry-pick bot OR the PR’s description is well formed with user-focused release notes that state the bug number, impact, cause, and resolution. Where appropriate, it should also contain information about how a user can identify whether a particular cluster is affected.
    - [x] verified