### PR TITLE
manifests/deployment: comply to restricted pod security level

### DIFF
--- a/manifests/0000_25_kube-scheduler-operator_06_deployment.yaml
+++ b/manifests/0000_25_kube-scheduler-operator_06_deployment.yaml
@@ -22,10 +22,19 @@ spec:
       labels:
         app: openshift-kube-scheduler-operator
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault    
       automountServiceAccountToken: false
       serviceAccountName: openshift-kube-scheduler-operator
       containers:
       - name: kube-scheduler-operator-container
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
         image: docker.io/openshift/origin-cluster-kube-scheduler-operator:v4.0
         imagePullPolicy: IfNotPresent
         command: ["cluster-kube-scheduler-operator", "operator"]


### PR DESCRIPTION
Starting from OpenShift 4.11 pod security admission is being activated. In OpenShift the default pod security admission level is going to be `restricted`. This PR fixes workloads from this repository. Concretely, the following violations have been detected:

```
{
  "objectRef": "openshift-kube-scheduler-operator/deployments/openshift-kube-scheduler-operator",
  "pod-security.kubernetes.io/audit-violations": "would violate PodSecurity \"restricted:latest\": allowPrivilegeEscalation != false (container \"kube-scheduler-operator-container\" must set securityContext.allowPrivilegeEscalation=false), unres
tricted capabilities (container \"kube-scheduler-operator-container\" must set securityContext.capabilities.drop=[\"ALL\"]), runAsNonRoot != true (pod or container \"kube-scheduler-operator-container\" must set securityContext.runAsNonRoot=true)
, seccompProfile (pod or container \"kube-scheduler-operator-container\" must set securityContext.seccompProfile.type to \"RuntimeDefault\" or \"Localhost\")"
}
```

Note: This is blocked until https://github.com/openshift/cluster-kube-apiserver-operator/pull/1338 merges.

/cc @stlaz 