### PR TITLE
Bug 2062459: Fix bootstrap leader election config

### DIFF
--- a/bindata/bootkube/config/bootstrap-config-overrides.yaml
+++ b/bindata/bootkube/config/bootstrap-config-overrides.yaml
@@ -1,2 +1,9 @@
 apiVersion: kubescheduler.config.k8s.io/v1beta3
 kind: KubeSchedulerConfiguration
+leaderElection:
+  leaseDuration: "137s"
+  renewDeadline: "107s"
+  retryPeriod: "26s"
+  leaderElect: true
+  resourceNamespace: "openshift-kube-scheduler"
+  resourceLock: "configmapsleases"


### PR DESCRIPTION
Previously we used to rely on configmaps for leader election. Starting 4.10 we switched to configmapsleases and this was updated in the scheduler config. This is causing bootstrap scheduler to use configmaps where as the newly created scheduler to use configmapsleases causing 2 schedulers(bootstrap scheduler + newly created scheduler) to run at the same time.

For a sample bootstrap scheduler log which failed:

```
apiVersion: kubescheduler.config.k8s.io/v1beta3
clientConnection:
  acceptContentTypes: ""
  burst: 100
  contentType: application/vnd.kubernetes.protobuf
  kubeconfig: /etc/kubernetes/secrets/kubeconfig
  qps: 50
enableContentionProfiling: true
enableProfiling: true
kind: KubeSchedulerConfiguration
leaderElection:
  leaderElect: true
  leaseDuration: 15s
  renewDeadline: 10s
  resourceLock: leases
  resourceName: kube-scheduler
  resourceNamespace: kube-system
  retryPeriod: 2s
```

which is different from the newly created scheduler:

```
apiVersion: kubescheduler.config.k8s.io/v1beta3
clientConnection:
  acceptContentTypes: ""
  burst: 100
  contentType: application/vnd.kubernetes.protobuf
  kubeconfig: /etc/kubernetes/static-pod-resources/configmaps/scheduler-kubeconfig/kubeconfig
  qps: 50
enableContentionProfiling: true
enableProfiling: true
kind: KubeSchedulerConfiguration
leaderElection:
  leaderElect: true
  leaseDuration: 2m17s
  renewDeadline: 1m47s
  resourceLock: configmapsleases
  resourceName: kube-scheduler
  resourceNamespace: openshift-kube-scheduler
  retryPeriod: 26s
```

This also means v1beta3 api should default to using configmapsleases in kube. I'll separately follow up upstream later.