### PR TITLE
Bump go.mod golang version to 1.19

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-8-release-golang-1.18-openshift-4.12
+  tag: rhel-8-release-golang-1.19-openshift-4.12

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.18-openshift-4.12 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-4.12 AS builder
 WORKDIR /go/src/github.com/openshift/cluster-kube-scheduler-operator
 COPY . .
 RUN make build --warn-undefined-variables

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/cluster-kube-scheduler-operator
 
-go 1.18
+go 1.19
 
 require (
 	github.com/blang/semver/v4 v4.0.0

--- a/pkg/operator/configobservation/scheduler/observe_scheduler.go
+++ b/pkg/operator/configobservation/scheduler/observe_scheduler.go
@@ -13,8 +13,9 @@ import (
 
 // observeSchedulerConfig syncs the scheduler policy-config from the openshift-config namespace to the kube-scheduler, if set
 // TODO(@damemi): This does not currently do much besides sync and delete the policy configmap if necessary,
-//  but when we completely switch over to the ComponentConfig API, we will need to re-introduce logic here which
-//  merges policy config information into the main scheduler config. See: https://github.com/openshift/cluster-kube-scheduler-operator/pull/255
+//
+//	but when we completely switch over to the ComponentConfig API, we will need to re-introduce logic here which
+//	merges policy config information into the main scheduler config. See: https://github.com/openshift/cluster-kube-scheduler-operator/pull/255
 func ObserveSchedulerConfig(genericListers configobserver.Listers, recorder events.Recorder, existingConfig map[string]interface{}) (map[string]interface{}, []error) {
 	listers := genericListers.(configobservation.Listers)
 	errs := []error{}

--- a/pkg/operator/configobservation/scheduler/observe_scheduler_test.go
+++ b/pkg/operator/configobservation/scheduler/observe_scheduler_test.go
@@ -15,8 +15,9 @@ import (
 )
 
 // TODO(@damemi): Update this to test to re-include checks that policy config is properly merged into ComponentConfig
-//  (Once we support ComponentConfig/Plugins and deprecate Policy config)
-//  Re: https://github.com/openshift/cluster-kube-scheduler-operator/pull/255
+//
+//	(Once we support ComponentConfig/Plugins and deprecate Policy config)
+//	Re: https://github.com/openshift/cluster-kube-scheduler-operator/pull/255
 func TestObserveSchedulerConfig(t *testing.T) {
 	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
 


### PR DESCRIPTION
Built on top of https://github.com/openshift/cluster-kube-scheduler-operator/pull/439