### PR TITLE
trt-589 bump library-go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/openshift/api v0.0.0-20220831183848-09c070622e2c
 	github.com/openshift/build-machinery-go v0.0.0-20220720161851-9b4f0386f6b0
 	github.com/openshift/client-go v0.0.0-20220831193253-4950ae70c8ea
-	github.com/openshift/library-go v0.0.0-20220831200629-330d9097d0f0
+	github.com/openshift/library-go v0.0.0-20221004015544-d6c64d0262cc
 	github.com/prometheus/client_golang v1.12.1
 	github.com/prometheus/common v0.32.1
 	github.com/spf13/cobra v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -398,8 +398,8 @@ github.com/openshift/build-machinery-go v0.0.0-20220720161851-9b4f0386f6b0 h1:uc
 github.com/openshift/build-machinery-go v0.0.0-20220720161851-9b4f0386f6b0/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20220831193253-4950ae70c8ea h1:7JbjIzWt3Q75ErY1PAZ+gCA+bErI6HSlpffHFmMMzqM=
 github.com/openshift/client-go v0.0.0-20220831193253-4950ae70c8ea/go.mod h1:+J8DqZC60acCdpYkwVy/KH4cudgWiFZRNOBeghCzdGA=
-github.com/openshift/library-go v0.0.0-20220831200629-330d9097d0f0 h1:WImCesg6dS8HXcvFpbGHMe/nKDzXSwSRXERid+XhUcQ=
-github.com/openshift/library-go v0.0.0-20220831200629-330d9097d0f0/go.mod h1:KPBAXGaq7pPmA+1wUVtKr5Axg3R68IomWDkzaOxIhxM=
+github.com/openshift/library-go v0.0.0-20221004015544-d6c64d0262cc h1:bmOGYOuO1pV6mSxIBwf9Q76pCV/18utG0DYlh4NJPeU=
+github.com/openshift/library-go v0.0.0-20221004015544-d6c64d0262cc/go.mod h1:KPBAXGaq7pPmA+1wUVtKr5Axg3R68IomWDkzaOxIhxM=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=

--- a/vendor/github.com/openshift/library-go/pkg/config/serving/server.go
+++ b/vendor/github.com/openshift/library-go/pkg/config/serving/server.go
@@ -47,7 +47,7 @@ func ToServerConfig(ctx context.Context, servingInfo configv1.HTTPServingInfo, a
 		err := wait.PollImmediateUntil(1*time.Second, func() (done bool, err error) {
 			lastApplyErr = authenticationOptions.ApplyTo(&config.Authentication, config.SecureServing, config.OpenAPIConfig)
 			if lastApplyErr != nil {
-				klog.V(4).Infof("Error initializing delegating authentication (will retry): %v", err)
+				klog.V(4).Infof("Error initializing delegating authentication (will retry): %v", lastApplyErr)
 				return false, nil
 			}
 			return true, nil

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -235,7 +235,7 @@ github.com/openshift/client-go/route/applyconfigurations/route/v1
 github.com/openshift/client-go/route/clientset/versioned
 github.com/openshift/client-go/route/clientset/versioned/scheme
 github.com/openshift/client-go/route/clientset/versioned/typed/route/v1
-# github.com/openshift/library-go v0.0.0-20220831200629-330d9097d0f0
+# github.com/openshift/library-go v0.0.0-20221004015544-d6c64d0262cc
 ## explicit; go 1.18
 github.com/openshift/library-go/pkg/assets
 github.com/openshift/library-go/pkg/authorization/hardcodedauthorizer


### PR DESCRIPTION
[Trt-589](https://issues.redhat.com//browse/Trt-589) is researching an issue where installer pods timeout, shutdown and enter a failed state triggering KubePodNotReady alerts.  library-go was updated to add milestone logging to track the progress and track down the issue.  Bumping the version to pull those changes in.