### PR TITLE
OCPBUGS-3041: guard controller: set an explicit hostname to avoid name collisions

### DIFF
--- a/bindata/bootkube/bootstrap-manifests/kube-scheduler-pod.yaml
+++ b/bindata/bootkube/bootstrap-manifests/kube-scheduler-pod.yaml
@@ -12,8 +12,8 @@ metadata:
 spec:
   containers:
   - name: kube-scheduler
-    image: {{ .Image }}
-    imagePullPolicy: {{ .ImagePullPolicy }}
+    image: '{{ .Image }}'
+    imagePullPolicy: '{{ .ImagePullPolicy }}'
     command: ["hyperkube", "kube-scheduler"]
     args:
     - --kubeconfig=/etc/kubernetes/secrets/kubeconfig
@@ -38,7 +38,7 @@ spec:
   hostNetwork: true
   volumes:
   - hostPath:
-      path: {{ .SecretsHostPath }}
+      path: '{{ .SecretsHostPath }}'
     name: secrets
   - hostPath:
       path: /var/log/bootstrap-control-plane

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/openshift/api v0.0.0-20221011103137-aeb3a767b193
 	github.com/openshift/build-machinery-go v0.0.0-20220913142420-e25cf57ea46d
 	github.com/openshift/client-go v0.0.0-20220831193253-4950ae70c8ea
-	github.com/openshift/library-go v0.0.0-20221021005159-d93563844063
+	github.com/openshift/library-go v0.0.0-20221128143913-7daae096c123
 	github.com/prometheus/client_golang v1.12.1
 	github.com/prometheus/common v0.32.1
 	github.com/spf13/cobra v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -398,8 +398,8 @@ github.com/openshift/build-machinery-go v0.0.0-20220913142420-e25cf57ea46d h1:RR
 github.com/openshift/build-machinery-go v0.0.0-20220913142420-e25cf57ea46d/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20220831193253-4950ae70c8ea h1:7JbjIzWt3Q75ErY1PAZ+gCA+bErI6HSlpffHFmMMzqM=
 github.com/openshift/client-go v0.0.0-20220831193253-4950ae70c8ea/go.mod h1:+J8DqZC60acCdpYkwVy/KH4cudgWiFZRNOBeghCzdGA=
-github.com/openshift/library-go v0.0.0-20221021005159-d93563844063 h1:Mn2LKR04FBEiXk1g2r6cB98G7M3sCUp58qb89Uz5kcE=
-github.com/openshift/library-go v0.0.0-20221021005159-d93563844063/go.mod h1:KPBAXGaq7pPmA+1wUVtKr5Axg3R68IomWDkzaOxIhxM=
+github.com/openshift/library-go v0.0.0-20221128143913-7daae096c123 h1:fbo6n5znassubZjWYqxGs2qrdKf+XTbMg81NzbYZAuI=
+github.com/openshift/library-go v0.0.0-20221128143913-7daae096c123/go.mod h1:KPBAXGaq7pPmA+1wUVtKr5Axg3R68IomWDkzaOxIhxM=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=

--- a/pkg/test/assets_test.go
+++ b/pkg/test/assets_test.go
@@ -15,7 +15,7 @@ func TestYamlCorrectness(t *testing.T) {
 }
 
 func readAllYaml(path string, t *testing.T) {
-	manifests, err := assets.New(path, render.TemplateData{}, assets.OnlyYaml)
+	manifests, err := assets.New(path, render.TemplateData{}, nil, assets.OnlyYaml)
 	if err != nil {
 		t.Errorf("Unexpected error reading manifests from %s: %v", path, err)
 	}

--- a/vendor/github.com/openshift/library-go/pkg/crypto/OWNERS
+++ b/vendor/github.com/openshift/library-go/pkg/crypto/OWNERS
@@ -1,0 +1,4 @@
+reviewers:
+  - stlaz
+approvers:
+  - stlaz

--- a/vendor/github.com/openshift/library-go/pkg/crypto/crypto.go
+++ b/vendor/github.com/openshift/library-go/pkg/crypto/crypto.go
@@ -19,6 +19,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"reflect"
 	"sort"
 	"strconv"
 	"sync"
@@ -828,13 +829,35 @@ func (ca *CA) MakeServerCertForDuration(hostnames sets.String, lifetime time.Dur
 }
 
 func (ca *CA) EnsureClientCertificate(certFile, keyFile string, u user.Info, expireDays int) (*TLSCertificateConfig, bool, error) {
-	certConfig, err := GetTLSCertificateConfig(certFile, keyFile)
+	certConfig, err := GetClientCertificate(certFile, keyFile, u)
 	if err != nil {
 		certConfig, err = ca.MakeClientCertificate(certFile, keyFile, u, expireDays)
 		return certConfig, true, err // true indicates we wrote the files.
 	}
-
 	return certConfig, false, nil
+}
+
+func GetClientCertificate(certFile, keyFile string, u user.Info) (*TLSCertificateConfig, error) {
+	certConfig, err := GetTLSCertificateConfig(certFile, keyFile)
+	if err != nil {
+		return nil, err
+	}
+
+	if subject := certConfig.Certs[0].Subject; subjectChanged(subject, userToSubject(u)) {
+		return nil, fmt.Errorf("existing client certificate in %s was issued for a different Subject (%s)",
+			certFile, subject)
+	}
+
+	return certConfig, nil
+}
+
+func subjectChanged(existing, expected pkix.Name) bool {
+	sort.Strings(existing.Organization)
+	sort.Strings(expected.Organization)
+
+	return existing.CommonName != expected.CommonName ||
+		existing.SerialNumber != expected.SerialNumber ||
+		!reflect.DeepEqual(existing.Organization, expected.Organization)
 }
 
 func (ca *CA) MakeClientCertificate(certFile, keyFile string, u user.Info, expireDays int) (*TLSCertificateConfig, error) {

--- a/vendor/github.com/openshift/library-go/pkg/operator/render/render.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/render/render.go
@@ -11,9 +11,12 @@ import (
 
 // WriteFiles writes the manifests and the bootstrap config file.
 func WriteFiles(opt *options.GenericOptions, fileConfig *options.FileConfig, templateData interface{}, additionalPredicates ...assets.FileInfoPredicate) error {
+	defaultPredicates := []assets.FileInfoPredicate{assets.OnlyYaml}
+	manifestPredicates := []assets.FileContentsPredicate{assets.InstallerFeatureSet(opt.FeatureSet)}
+
 	// write assets
 	for _, manifestDir := range []string{"bootstrap-manifests", "manifests"} {
-		manifests, err := assets.New(filepath.Join(opt.TemplatesDir, manifestDir), templateData, append(additionalPredicates, assets.OnlyYaml)...)
+		manifests, err := assets.New(filepath.Join(opt.TemplatesDir, manifestDir), templateData, manifestPredicates, append(additionalPredicates, defaultPredicates...)...)
 		if err != nil {
 			return fmt.Errorf("failed rendering assets: %v", err)
 		}

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/OWNERS
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/OWNERS
@@ -1,6 +1,10 @@
 reviewers:
+  - dgrisonnet
   - p0lyn0mial
   - sttts
+  - tkashem
 approvers:
+  - dgrisonnet
   - p0lyn0mial
   - sttts
+  - tkashem

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/guard/guard_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/guard/guard_controller.go
@@ -2,10 +2,12 @@ package guard
 
 import (
 	"context"
+	"crypto/sha1"
 	_ "embed"
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -96,6 +98,22 @@ func getInstallerPodImageFromEnv() string {
 
 func getGuardPodName(prefix, nodeName string) string {
 	return fmt.Sprintf("%s-guard-%s", prefix, nodeName)
+}
+
+func getGuardPodHostname(namespace, nodeName string) string {
+	// The hostname is not used by the controller and not expected to be used at all.
+	// Generate the shorted but unique hostname so the hostname length is always
+	// under 63 characters as specified by hostnameMaxLen so the kubelet does not
+	// truncate the name to avoid conflicting hostnames.
+	// See OCPBUGS-3041 for more details.
+	//
+	// The controller creates exactly one guard pod per each node.
+	// Making the nodename a unique identifier for each guard pod.
+	// Adding the namespace to make the input for the generated hash longer
+	hash := sha1.Sum([]byte(fmt.Sprintf("%s-%s", namespace, nodeName)))
+	hostname := "guard-" + fmt.Sprintf("%x", string(hash[:])) + "-end" //6 + 40 + 4 = 50 chars
+	// a lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character
+	return strings.Replace(hostname, ".", "-", -1)
 }
 
 func getGuardPDBName(prefix string) string {
@@ -264,6 +282,7 @@ func (c *GuardController) sync(ctx context.Context, syncCtx factory.SyncContext)
 
 			pod.ObjectMeta.Name = getGuardPodName(c.podResourcePrefix, node.Name)
 			pod.ObjectMeta.Namespace = c.targetNamespace
+			pod.Spec.Hostname = getGuardPodHostname(c.targetNamespace, node.Name)
 			pod.Spec.NodeName = node.Name
 			pod.Spec.Containers[0].Image = c.installerPodImageFn()
 			pod.Spec.Containers[0].ReadinessProbe.HTTPGet.Host = operands[node.Name].Status.PodIP
@@ -284,6 +303,10 @@ func (c *GuardController) sync(ctx context.Context, syncCtx factory.SyncContext)
 				}
 				if actual.Spec.Containers[0].ReadinessProbe.HTTPGet.Host != pod.Spec.Containers[0].ReadinessProbe.HTTPGet.Host {
 					klog.V(5).Infof("Operand PodIP changed, deleting %v so the guard can be re-created", pod.Name)
+					delete = true
+				}
+				if actual.Spec.Hostname != pod.Spec.Hostname {
+					klog.V(5).Infof("Guard Hostname changed, deleting %v so the guard can be re-created", pod.Name)
 					delete = true
 				}
 				if delete {

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/installerstate/installer_state_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/installerstate/installer_state_controller.go
@@ -3,6 +3,7 @@ package installerstate
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -59,6 +60,14 @@ var degradedConditionNames = []string{
 	"InstallerPodNetworkingDegraded",
 }
 
+func installerNameToRevision(name string) (int, error) {
+	parts := strings.Split(name, "-")
+	if len(parts) < 2 {
+		return 0, fmt.Errorf("Installer name %v is invalid, missing revision number", name)
+	}
+	return strconv.Atoi(parts[1])
+}
+
 func (c *InstallerStateController) sync(ctx context.Context, syncCtx factory.SyncContext) error {
 	pods, err := c.podsGetter.Pods(c.targetNamespace).List(ctx, metav1.ListOptions{
 		LabelSelector: labels.SelectorFromSet(labels.Set{"app": "installer"}).String(),
@@ -67,19 +76,41 @@ func (c *InstallerStateController) sync(ctx context.Context, syncCtx factory.Syn
 		return err
 	}
 
+	masterRevisions := make(map[string][]*v1.Pod)
+	installerHighestRunningRevision := make(map[string]int)
+	for _, pod := range pods.Items {
+		p := pod
+		masterRevisions[pod.Spec.NodeName] = append(masterRevisions[pod.Spec.NodeName], &p)
+	}
+	// find the highest revision of a non-pending pod on each master node
+	for masterNode, pods := range masterRevisions {
+		maxRunningRev := 0
+		for _, pod := range pods {
+			if pod.Status.Phase != v1.PodPending || pod.Status.StartTime == nil {
+				rev, err := installerNameToRevision(pod.Name)
+				if err != nil {
+					return err
+				}
+				if rev > maxRunningRev {
+					maxRunningRev = rev
+				}
+			}
+		}
+		installerHighestRunningRevision[masterNode] = maxRunningRev
+	}
+
 	// collect all startingObjects that are in pending state for longer than maxToleratedPodPendingDuration
 	pendingPods := []*v1.Pod{}
 	for _, pod := range pods.Items {
 		if pod.Status.Phase != v1.PodPending || pod.Status.StartTime == nil {
 			continue
 		}
-		if c.timeNowFn().Sub(pod.Status.StartTime.Time) >= maxToleratedPodPendingDuration {
+		if rev, _ := installerNameToRevision(pod.Name); c.timeNowFn().Sub(pod.Status.StartTime.Time) >= maxToleratedPodPendingDuration && rev >= installerHighestRunningRevision[pod.Spec.NodeName] {
 			pendingPods = append(pendingPods, pod.DeepCopy())
 		}
 	}
 
-	// in theory, there should never be two installer startingObjects pending as we don't roll new installer pod
-	// until the previous/existing pod has finished its job.
+	// handle pending installer pods conditions
 	foundConditions := []operatorv1.OperatorCondition{}
 	foundConditions = append(foundConditions, c.handlePendingInstallerPods(syncCtx.Recorder(), pendingPods)...)
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -238,7 +238,7 @@ github.com/openshift/client-go/route/applyconfigurations/route/v1
 github.com/openshift/client-go/route/clientset/versioned
 github.com/openshift/client-go/route/clientset/versioned/scheme
 github.com/openshift/client-go/route/clientset/versioned/typed/route/v1
-# github.com/openshift/library-go v0.0.0-20221021005159-d93563844063
+# github.com/openshift/library-go v0.0.0-20221128143913-7daae096c123
 ## explicit; go 1.18
 github.com/openshift/library-go/pkg/assets
 github.com/openshift/library-go/pkg/authorization/hardcodedauthorizer


### PR DESCRIPTION
To avoid:
```
Oct 28 23:58:55.693391 ci-op-3hj6pnwf-4f6ab-lv57z-master-1 kubenswrapper[1657]: E1028 23:58:55.693346    1657 kubelet_pods.go:413] "Hostname for pod was too long, truncated it" podName="openshift-kube-scheduler-guard-ci-op-3hj6pnwf-4f6ab-lv57z-master-1" hostnameMaxLen=63 truncatedHostname="openshift-kube-scheduler-guard-ci-op-3hj6pnwf-4f6ab-lv57z-maste"
Oct 28 23:59:03.735726 ci-op-3hj6pnwf-4f6ab-lv57z-master-0 kubenswrapper[1670]: E1028 23:59:03.735671    1670 kubelet_pods.go:413] "Hostname for pod was too long, truncated it" podName="openshift-kube-scheduler-guard-ci-op-3hj6pnwf-4f6ab-lv57z-master-0" hostnameMaxLen=63 truncatedHostname="openshift-kube-scheduler-guard-ci-op-3hj6pnwf-4f6ab-lv57z-maste"
Oct 28 23:59:11.168082 ci-op-3hj6pnwf-4f6ab-lv57z-master-2 kubenswrapper[1667]: E1028 23:59:11.168041    1667 kubelet_pods.go:413] "Hostname for pod was too long, truncated it" podName="openshift-kube-scheduler-guard-ci-op-3hj6pnwf-4f6ab-lv57z-master-2" hostnameMaxLen=63 truncatedHostname="openshift-kube-scheduler-guard-ci-op-3hj6pnwf-4f6ab-lv57z-maste"
```

with identical `truncatedHostname="openshift-kube-scheduler-guard-ci-op-3hj6pnwf-4f6ab-lv57z-maste"` hostname. The new hostname is set to:
- `guard-ci-op-3hj6pnwf-4f6ab-lv57z-master-0`
- `guard-ci-op-3hj6pnwf-4f6ab-lv57z-master-1`
- `guard-ci-op-3hj6pnwf-4f6ab-lv57z-master-2`

Testing https://github.com/openshift/library-go/pull/1427