### PR TITLE
Drop flags removed in k8s 1.26

### DIFF
--- a/bindata/bootkube/bootstrap-manifests/kube-scheduler-pod.yaml
+++ b/bindata/bootkube/bootstrap-manifests/kube-scheduler-pod.yaml
@@ -21,8 +21,6 @@ spec:
     - --cert-dir=/var/run/kubernetes
     - --authentication-kubeconfig=/etc/kubernetes/secrets/kubeconfig
     - --authorization-kubeconfig=/etc/kubernetes/secrets/kubeconfig
-    - --logtostderr=false
-    - --alsologtostderr
     - --v=2
     - --log-file=/var/log/bootstrap-control-plane/kube-scheduler.log
     resources:


### PR DESCRIPTION
These flags were removed in https://github.com/kubernetes/kubernetes/pull/112120, based on [the defaults](https://github.com/kubernetes/enhancements/blob/master/keps/sig-instrumentation/2845-deprecate-klog-specific-flags-in-k8s-components/README.md#logging-defaults)  we should be good with just dropping these flags. 