### PR TITLE
remove use of deprecated klog flags

### DIFF
--- a/bindata/bootkube/bootstrap-manifests/kube-scheduler-pod.yaml
+++ b/bindata/bootkube/bootstrap-manifests/kube-scheduler-pod.yaml
@@ -22,7 +22,6 @@ spec:
     - --authentication-kubeconfig=/etc/kubernetes/secrets/kubeconfig
     - --authorization-kubeconfig=/etc/kubernetes/secrets/kubeconfig
     - --v=2
-    - --log-file=/var/log/bootstrap-control-plane/kube-scheduler.log
     resources:
       requests:
         memory: 50Mi


### PR DESCRIPTION
Previously deprecated klog flags will be removed completely in kube 1.26.
Logs of bootstrap pods were previously using the --log-file flag, will be available in the cri-o container logs instead.