### PR TITLE
OCPBUGS-4551: guard controller: set an explicit hostname to avoid name collisions

### DIFF
--- a/bindata/bootkube/bootstrap-manifests/kube-scheduler-pod.yaml
+++ b/bindata/bootkube/bootstrap-manifests/kube-scheduler-pod.yaml
@@ -12,8 +12,8 @@ metadata:
 spec:
   containers:
   - name: kube-scheduler
-    image: {{ .Image }}
-    imagePullPolicy: {{ .ImagePullPolicy }}
+    image: '{{ .Image }}'
+    imagePullPolicy: '{{ .ImagePullPolicy }}'
     command: ["hyperkube", "kube-scheduler"]
     args:
     - --kubeconfig=/etc/kubernetes/secrets/kubeconfig
@@ -38,7 +38,7 @@ spec:
   hostNetwork: true
   volumes:
   - hostPath:
-      path: {{ .SecretsHostPath }}
+      path: '{{ .SecretsHostPath }}'
     name: secrets
   - hostPath:
       path: /var/log/bootstrap-control-plane

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/openshift/api v0.0.0-20220525145417-ee5b62754c68
 	github.com/openshift/build-machinery-go v0.0.0-20211213093930-7e33a7eb4ce3
 	github.com/openshift/client-go v0.0.0-20220525160904-9e1acff93e4a
-	github.com/openshift/library-go v0.0.0-20220525173854-9b950a41acdc
+	github.com/openshift/library-go v0.0.0-20230113124823-060d466c4057
 	github.com/prometheus/client_golang v1.12.1
 	github.com/prometheus/common v0.32.1
 	github.com/spf13/cobra v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -498,8 +498,8 @@ github.com/openshift/build-machinery-go v0.0.0-20211213093930-7e33a7eb4ce3 h1:65
 github.com/openshift/build-machinery-go v0.0.0-20211213093930-7e33a7eb4ce3/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20220525160904-9e1acff93e4a h1:ylsEgoC8Dlg4A0C1TLH0A4x/TZao7k1YveLwROhRUdk=
 github.com/openshift/client-go v0.0.0-20220525160904-9e1acff93e4a/go.mod h1:eDO5QeVi2IiXmDwB0e2z1DpAznWroZKe978pzZwFBzg=
-github.com/openshift/library-go v0.0.0-20220525173854-9b950a41acdc h1:j+upvKc1uLzuL+q/JXie8+IMohOooTCaEC9w+4d1Ztk=
-github.com/openshift/library-go v0.0.0-20220525173854-9b950a41acdc/go.mod h1:AMZwYwSdbvALDl3QobEzcJ2IeDO7DYLsr42izKzh524=
+github.com/openshift/library-go v0.0.0-20230113124823-060d466c4057 h1:2HoEfS3OJ7KybyZMuCChH44DLBHgU1rLEzIlTDhcbbE=
+github.com/openshift/library-go v0.0.0-20230113124823-060d466c4057/go.mod h1:AMZwYwSdbvALDl3QobEzcJ2IeDO7DYLsr42izKzh524=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/guard/guard_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/guard/guard_controller.go
@@ -2,10 +2,12 @@ package guard
 
 import (
 	"context"
+	"crypto/sha1"
 	_ "embed"
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -96,6 +98,22 @@ func getInstallerPodImageFromEnv() string {
 
 func getGuardPodName(prefix, nodeName string) string {
 	return fmt.Sprintf("%s-guard-%s", prefix, nodeName)
+}
+
+func getGuardPodHostname(namespace, nodeName string) string {
+	// The hostname is not used by the controller and not expected to be used at all.
+	// Generate the shorted but unique hostname so the hostname length is always
+	// under 63 characters as specified by hostnameMaxLen so the kubelet does not
+	// truncate the name to avoid conflicting hostnames.
+	// See OCPBUGS-3041 for more details.
+	//
+	// The controller creates exactly one guard pod per each node.
+	// Making the nodename a unique identifier for each guard pod.
+	// Adding the namespace to make the input for the generated hash longer
+	hash := sha1.Sum([]byte(fmt.Sprintf("%s-%s", namespace, nodeName)))
+	hostname := "guard-" + fmt.Sprintf("%x", string(hash[:])) + "-end" //6 + 40 + 4 = 50 chars
+	// a lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character
+	return strings.Replace(hostname, ".", "-", -1)
 }
 
 func getGuardPDBName(prefix string) string {
@@ -264,6 +282,7 @@ func (c *GuardController) sync(ctx context.Context, syncCtx factory.SyncContext)
 
 			pod.ObjectMeta.Name = getGuardPodName(c.podResourcePrefix, node.Name)
 			pod.ObjectMeta.Namespace = c.targetNamespace
+			pod.Spec.Hostname = getGuardPodHostname(c.targetNamespace, node.Name)
 			pod.Spec.NodeName = node.Name
 			pod.Spec.Containers[0].Image = c.installerPodImageFn()
 			pod.Spec.Containers[0].ReadinessProbe.HTTPGet.Host = operands[node.Name].Status.PodIP
@@ -284,6 +303,10 @@ func (c *GuardController) sync(ctx context.Context, syncCtx factory.SyncContext)
 				}
 				if actual.Spec.Containers[0].ReadinessProbe.HTTPGet.Host != pod.Spec.Containers[0].ReadinessProbe.HTTPGet.Host {
 					klog.V(5).Infof("Operand PodIP changed, deleting %v so the guard can be re-created", pod.Name)
+					delete = true
+				}
+				if actual.Spec.Hostname != pod.Spec.Hostname {
+					klog.V(5).Infof("Guard Hostname changed, deleting %v so the guard can be re-created", pod.Name)
 					delete = true
 				}
 				if delete {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -226,7 +226,7 @@ github.com/openshift/client-go/operator/clientset/versioned/typed/operator/v1alp
 github.com/openshift/client-go/route/clientset/versioned
 github.com/openshift/client-go/route/clientset/versioned/scheme
 github.com/openshift/client-go/route/clientset/versioned/typed/route/v1
-# github.com/openshift/library-go v0.0.0-20220525173854-9b950a41acdc
+# github.com/openshift/library-go v0.0.0-20230113124823-060d466c4057
 ## explicit; go 1.17
 github.com/openshift/library-go/pkg/assets
 github.com/openshift/library-go/pkg/authorization/hardcodedauthorizer


### PR DESCRIPTION
Backporting https://github.com/openshift/cluster-kube-scheduler-operator/pull/446