### PR TITLE
bind http metrics to localhost

### DIFF
--- a/bindata/assets/config/defaultconfig.yaml
+++ b/bindata/assets/config/defaultconfig.yaml
@@ -11,3 +11,5 @@ leaderElection:
   resourceLock: "configmapsleases"
 enableProfiling: false
 enableContentionProfiling: false
+metricsBindAddress: "127.0.0.1:10251"
+healthzBindAddress: "127.0.0.1:10251"

--- a/bindata/bootkube/config/bootstrap-config-overrides.yaml
+++ b/bindata/bootkube/config/bootstrap-config-overrides.yaml
@@ -9,3 +9,5 @@ leaderElection:
   resourceLock: "configmapsleases"
 enableProfiling: false
 enableContentionProfiling: false
+metricsBindAddress: "127.0.0.1:10251"
+healthzBindAddress: "127.0.0.1:10251"


### PR DESCRIPTION
[issue 473](https://github.com/openshift/cluster-kube-scheduler-operator/issues/473)

Restrict access to http metrics