### PR TITLE
OCPBUGS-14652: disable debug pporf with unauthenticated port for 4.12

### DIFF
--- a/bindata/assets/config/defaultconfig.yaml
+++ b/bindata/assets/config/defaultconfig.yaml
@@ -9,3 +9,5 @@ leaderElection:
   leaderElect: true
   resourceNamespace: "openshift-kube-scheduler"
   resourceLock: "configmapsleases"
+enableProfiling: false
+enableContentionProfiling: false

--- a/bindata/bootkube/config/bootstrap-config-overrides.yaml
+++ b/bindata/bootkube/config/bootstrap-config-overrides.yaml
@@ -7,3 +7,5 @@ leaderElection:
   leaderElect: true
   resourceNamespace: "openshift-kube-scheduler"
   resourceLock: "configmapsleases"
+enableProfiling: false
+enableContentionProfiling: false


### PR DESCRIPTION
disable debug pporf with unauthenticated port for ocp 4.12

has resolved in https://github.com/openshift/cluster-kube-scheduler-operator/pull/468, should backporting to both 4.13 and 4.12