### PR TITLE
Update resource mounts to be read-only

### DIFF
--- a/bindata/assets/kube-scheduler/pod.yaml
+++ b/bindata/assets/kube-scheduler/pod.yaml
@@ -121,8 +121,9 @@ spec:
   tolerations:
   - operator: "Exists"
   volumes:
-  - hostPath:
-      path: /etc/kubernetes/static-pod-resources/kube-scheduler-pod-REVISION
+  - configMap:
+      path: kube-scheduler-pod-REVISION
+      defaultMode: 384
     name: resource-dir
   - hostPath:
       path: /etc/kubernetes/static-pod-resources/kube-scheduler-certs

--- a/pkg/operator/targetconfigcontroller/testdata/ks_pod_scenario_1.yaml
+++ b/pkg/operator/targetconfigcontroller/testdata/ks_pod_scenario_1.yaml
@@ -15,8 +15,9 @@ metadata:
 spec:
   volumes:
     - name: resource-dir
-      hostPath:
-        path: "/etc/kubernetes/static-pod-resources/kube-scheduler-pod-REVISION"
+      configMap:
+        name: kube-scheduler-pod-REVISION
+        defaultMode: 384
     - name: cert-dir
       hostPath:
         path: "/etc/kubernetes/static-pod-resources/kube-scheduler-certs"

--- a/pkg/operator/targetconfigcontroller/testdata/ks_pod_scenario_2.yaml
+++ b/pkg/operator/targetconfigcontroller/testdata/ks_pod_scenario_2.yaml
@@ -15,8 +15,9 @@ metadata:
 spec:
   volumes:
     - name: resource-dir
-      hostPath:
-        path: "/etc/kubernetes/static-pod-resources/kube-scheduler-pod-REVISION"
+      configMap:
+        name: kube-scheduler-pod-REVISION
+        defaultMode: 384
     - name: cert-dir
       hostPath:
         path: "/etc/kubernetes/static-pod-resources/kube-scheduler-certs"

--- a/pkg/operator/targetconfigcontroller/testdata/ks_pod_scenario_3.yaml
+++ b/pkg/operator/targetconfigcontroller/testdata/ks_pod_scenario_3.yaml
@@ -15,8 +15,9 @@ metadata:
 spec:
   volumes:
     - name: resource-dir
-      hostPath:
-        path: "/etc/kubernetes/static-pod-resources/kube-scheduler-pod-REVISION"
+      configMap:
+        name: kube-scheduler-pod-REVISION
+        defaultMode: 384
     - name: cert-dir
       hostPath:
         path: "/etc/kubernetes/static-pod-resources/kube-scheduler-certs"


### PR DESCRIPTION
Per CIS OpenShift recommendation 1.1.15, the `kubeconfig` should only be readable (e.g., permissions set to 0600 or more restrictive). Today, the default permissions for the `kubeconfig` file are 644.

This patch updates the volume mounts to leverage the `readOnly` option to address this control by default.