### PR TITLE
remove loglevel in deploy

### DIFF
--- a/manifests/0000_25_kube-scheduler-operator_06_deployment.yaml
+++ b/manifests/0000_25_kube-scheduler-operator_06_deployment.yaml
@@ -40,7 +40,6 @@ spec:
         command: ["cluster-kube-scheduler-operator", "operator"]
         args:
         - "--config=/var/run/configmaps/config/config.yaml"
-        - "-v=2"
         resources:
           requests:
             memory: 50Mi


### PR DESCRIPTION
There is no need to set the log level in operator deploy, the operator log can be set by operator.spec.operatorLogLevel