### PR TITLE
OCPNODE-1886: Migrate from kubescheduler.config.k8s.io/v1beta3 to v1

### DIFF
--- a/bindata/assets/config/defaultconfig-postbootstrap-highnodeutilization.yaml
+++ b/bindata/assets/config/defaultconfig-postbootstrap-highnodeutilization.yaml
@@ -1,4 +1,4 @@
-apiVersion: kubescheduler.config.k8s.io/v1beta3
+apiVersion: kubescheduler.config.k8s.io/v1
 kind: KubeSchedulerConfiguration
 profiles:
   - schedulerName: default-scheduler

--- a/bindata/assets/config/defaultconfig-postbootstrap-lownodeutilization.yaml
+++ b/bindata/assets/config/defaultconfig-postbootstrap-lownodeutilization.yaml
@@ -1,2 +1,2 @@
-apiVersion: kubescheduler.config.k8s.io/v1beta3
+apiVersion: kubescheduler.config.k8s.io/v1
 kind: KubeSchedulerConfiguration

--- a/bindata/assets/config/defaultconfig-postbootstrap-noscoring.yaml
+++ b/bindata/assets/config/defaultconfig-postbootstrap-noscoring.yaml
@@ -1,4 +1,4 @@
-apiVersion: kubescheduler.config.k8s.io/v1beta3
+apiVersion: kubescheduler.config.k8s.io/v1
 kind: KubeSchedulerConfiguration
 profiles:
   - schedulerName: default-scheduler

--- a/bindata/assets/config/defaultconfig.yaml
+++ b/bindata/assets/config/defaultconfig.yaml
@@ -1,4 +1,4 @@
-apiVersion: kubescheduler.config.k8s.io/v1beta3
+apiVersion: kubescheduler.config.k8s.io/v1
 kind: KubeSchedulerConfiguration
 clientConnection:
   kubeconfig: /etc/kubernetes/static-pod-resources/configmaps/scheduler-kubeconfig/kubeconfig

--- a/bindata/bootkube/config/bootstrap-config-overrides.yaml
+++ b/bindata/bootkube/config/bootstrap-config-overrides.yaml
@@ -1,4 +1,4 @@
-apiVersion: kubescheduler.config.k8s.io/v1beta3
+apiVersion: kubescheduler.config.k8s.io/v1
 kind: KubeSchedulerConfiguration
 leaderElection:
   leaseDuration: "137s"


### PR DESCRIPTION
https://github.com/kubernetes/kubernetes/pull/119994/ removes `kubescheduler.config.k8s.io/v1beta3` entirely, and this will prevent us from running k8s 1.29. `kubescheduler.config.k8s.io/v1` is available since 1.25.

/assign @ingvagabund 