### PR TITLE
OCPBUGS-23463: bump(library-go)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/openshift/api v0.0.0-20231019105552-3a98ec045aeb
 	github.com/openshift/build-machinery-go v0.0.0-20230816154005-5a38e1bfd880
 	github.com/openshift/client-go v0.0.0-20231018150822-6e226e2825a6
-	github.com/openshift/library-go v0.0.0-20231017173800-126f85ed0cc7
+	github.com/openshift/library-go v0.0.0-20231128084459-0dbbc2c74004
 	github.com/prometheus/client_golang v1.16.0
 	github.com/prometheus/common v0.44.0
 	github.com/spf13/cobra v1.7.0
@@ -21,6 +21,7 @@ require (
 	k8s.io/client-go v0.28.3
 	k8s.io/component-base v0.28.3
 	k8s.io/klog/v2 v2.100.1
+	k8s.io/utils v0.0.0-20230726121419-3b25d923346b
 )
 
 require (
@@ -108,7 +109,6 @@ require (
 	k8s.io/kms v0.28.3 // indirect
 	k8s.io/kube-aggregator v0.28.3 // indirect
 	k8s.io/kube-openapi v0.0.0-20230717233707-2695361300d9 // indirect
-	k8s.io/utils v0.0.0-20230726121419-3b25d923346b // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.1.2 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/kube-storage-version-migrator v0.0.6-0.20230721195810-5c8923c5ff96 // indirect

--- a/go.sum
+++ b/go.sum
@@ -95,6 +95,7 @@ github.com/felixge/httpsnoop v1.0.3 h1:s/nj+GCswXYzN5v2DpNMuMQYe+0DDwt5WVCU6CWBd
 github.com/felixge/httpsnoop v1.0.3/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
 github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
+github.com/fvbommel/sortorder v1.1.0 h1:fUmoe+HLsBTctBDoaBwpQo5N+nrCp8g/BjKb/6ZQmYw=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
@@ -240,8 +241,8 @@ github.com/openshift/build-machinery-go v0.0.0-20230816154005-5a38e1bfd880 h1:FF
 github.com/openshift/build-machinery-go v0.0.0-20230816154005-5a38e1bfd880/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20231018150822-6e226e2825a6 h1:3wgEtuYbZ76oOXjhSJ2p1m0lftgghK0XlR9guG2aKhA=
 github.com/openshift/client-go v0.0.0-20231018150822-6e226e2825a6/go.mod h1:Fkn7VRruQ4KwNGeaUmi9QgqLk/d7U6cj+UiP8b+0hiQ=
-github.com/openshift/library-go v0.0.0-20231017173800-126f85ed0cc7 h1:pJLcCSJzdiWCaJ4bAepgnvwMdP33LumbVJyWSW7+3ng=
-github.com/openshift/library-go v0.0.0-20231017173800-126f85ed0cc7/go.mod h1:jgxNp8aApJnZtECid9SUSr5Bu6DLo8Hfdv1DgFZaYA8=
+github.com/openshift/library-go v0.0.0-20231128084459-0dbbc2c74004 h1:VQ0Ptz7yBMfe3DC9D1h0SMuh5VSP34NMZ9g4yBjgw5c=
+github.com/openshift/library-go v0.0.0-20231128084459-0dbbc2c74004/go.mod h1:8UzmrBMCn7+GzouL8DVYkL9COBQTB1Ggd13/mHJQCUg=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -678,4 +679,3 @@ sigs.k8s.io/structured-merge-diff/v4 v4.2.3 h1:PRbqxJClWWYMNV1dhaG4NsibJbArud9kF
 sigs.k8s.io/structured-merge-diff/v4 v4.2.3/go.mod h1:qjx8mGObPmV2aSZepjQjbmb2ihdVs8cGKBraizNC69E=
 sigs.k8s.io/yaml v1.3.0 h1:a2VclLzOGrwOHDiV8EfBGhvjHvP46CtW5j6POvhYGGo=
 sigs.k8s.io/yaml v1.3.0/go.mod h1:GeOyir5tyXNByN85N/dRIT9es5UQNerPYEKK56eTBm8=
-vbom.ml/util v0.0.0-20180919145318-efcd4e0f9787 h1:O69FD9pJA4WUZlEwYatBEEkRWKQ5cKodWpdKTrCS/iQ=

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -28,11 +28,14 @@ import (
 	"github.com/openshift/library-go/pkg/operator/staticresourcecontroller"
 	"github.com/openshift/library-go/pkg/operator/status"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
+
+	policyv1 "k8s.io/api/policy/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
 )
 
 func RunOperator(ctx context.Context, cc *controllercmd.ControllerContext) error {
@@ -158,6 +161,7 @@ func RunOperator(ctx context.Context, cc *controllercmd.ControllerContext) error
 			"cluster-kube-scheduler-operator",
 			"10259",
 			"healthz",
+			ptr.To(policyv1.AlwaysAllow),
 			func() (bool, bool, error) {
 				isSNO, precheckSucceeded, err := common.NewIsSingleNodePlatformFn(configInformers.Config().V1().Infrastructures())()
 				// create only when not a single node topology

--- a/vendor/github.com/openshift/library-go/pkg/operator/configobserver/apiserver/observe_tlssecurityprofile.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/configobserver/apiserver/observe_tlssecurityprofile.go
@@ -20,6 +20,12 @@ func ObserveTLSSecurityProfile(genericListers configobserver.Listers, recorder e
 	return innerTLSSecurityProfileObservations(genericListers, recorder, existingConfig, []string{"servingInfo", "minTLSVersion"}, []string{"servingInfo", "cipherSuites"})
 }
 
+// ObserveTLSSecurityProfileWithPaths is like ObserveTLSSecurityProfile, but accepts
+// custom paths for ServingInfo.MinTLSVersion and ServingInfo.CipherSuites fields of observed config.
+func ObserveTLSSecurityProfileWithPaths(genericListers configobserver.Listers, recorder events.Recorder, existingConfig map[string]interface{}, minTLSVersionPath, cipherSuitesPath []string) (map[string]interface{}, []error) {
+	return innerTLSSecurityProfileObservations(genericListers, recorder, existingConfig, minTLSVersionPath, cipherSuitesPath)
+}
+
 // ObserveTLSSecurityProfileToArguments observes APIServer.Spec.TLSSecurityProfile field and sets
 // the tls-min-version and tls-cipher-suites fileds of observedConfig.apiServerArguments
 func ObserveTLSSecurityProfileToArguments(genericListers configobserver.Listers, recorder events.Recorder, existingConfig map[string]interface{}) (map[string]interface{}, []error) {

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/rbac.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/rbac.go
@@ -2,7 +2,6 @@ package resourceapply
 
 import (
 	"context"
-	"fmt"
 
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -15,12 +14,8 @@ import (
 	"github.com/openshift/library-go/pkg/operator/resource/resourcemerge"
 )
 
-// ApplyClusterRole merges objectmeta, requires rules, aggregation rules are not allowed for now.
+// ApplyClusterRole merges objectmeta, requires rules.
 func ApplyClusterRole(ctx context.Context, client rbacclientv1.ClusterRolesGetter, recorder events.Recorder, required *rbacv1.ClusterRole) (*rbacv1.ClusterRole, bool, error) {
-	if required.AggregationRule != nil && len(required.AggregationRule.ClusterRoleSelectors) != 0 {
-		return nil, false, fmt.Errorf("cannot create an aggregated cluster role")
-	}
-
 	existing, err := client.ClusterRoles().Get(ctx, required.Name, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
 		requiredCopy := required.DeepCopy()
@@ -37,13 +32,23 @@ func ApplyClusterRole(ctx context.Context, client rbacclientv1.ClusterRolesGette
 	existingCopy := existing.DeepCopy()
 
 	resourcemerge.EnsureObjectMeta(modified, &existingCopy.ObjectMeta, required.ObjectMeta)
-	contentSame := equality.Semantic.DeepEqual(existingCopy.Rules, required.Rules)
-	if contentSame && !*modified {
+	rulesContentSame := equality.Semantic.DeepEqual(existingCopy.Rules, required.Rules)
+	aggregationRuleContentSame := equality.Semantic.DeepEqual(existingCopy.AggregationRule, required.AggregationRule)
+
+	if aggregationRuleContentSame && rulesContentSame && !*modified {
 		return existingCopy, false, nil
 	}
 
-	existingCopy.Rules = required.Rules
-	existingCopy.AggregationRule = nil
+	if !aggregationRuleContentSame {
+		existingCopy.AggregationRule = required.AggregationRule
+	}
+
+	// The control plane controller that reconciles ClusterRoles
+	// overwrites any values that are manually specified in the rules field of an aggregate ClusterRole.
+	// As such skip reconciling on the Rules field when the AggregationRule is set.
+	if !rulesContentSame && required.AggregationRule == nil {
+		existingCopy.Rules = required.Rules
+	}
 
 	if klog.V(4).Enabled() {
 		klog.Infof("ClusterRole %q changes: %v", required.Name, JSONPatchNoError(existing, existingCopy))

--- a/vendor/github.com/openshift/library-go/pkg/operator/revisioncontroller/revision_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/revisioncontroller/revision_controller.go
@@ -115,7 +115,7 @@ func (c RevisionController) createRevisionIfNeeded(ctx context.Context, recorder
 	if _, updated, updateError := c.operatorClient.UpdateLatestRevisionOperatorStatus(ctx, nextRevision, v1helpers.UpdateConditionFn(cond)); updateError != nil {
 		return true, updateError
 	} else if updated {
-		recorder.Eventf("RevisionCreate", "Revision %d created because %s", latestAvailableRevision, reason)
+		recorder.Eventf("RevisionCreate", "Revision %d created because %s", nextRevision, reason)
 	}
 
 	return false, nil
@@ -289,6 +289,8 @@ func (c RevisionController) sync(ctx context.Context, syncCtx factory.SyncContex
 	if !management.IsOperatorManaged(operatorSpec.ManagementState) {
 		return nil
 	}
+
+	klog.V(2).Infof("status.LatestAvailableRevision: %v, resourceVersion: %v", latestAvailableRevision, resourceVersion)
 
 	// If the operator status has 0 as its latest available revision, this is either the first revision
 	// or possibly the operator resource was deleted and reset back to 0, which is not what we want so check configmaps

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/guard/guard_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/guard/guard_controller.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -23,6 +24,7 @@ import (
 	corelisterv1 "k8s.io/client-go/listers/core/v1"
 	policylisterv1 "k8s.io/client-go/listers/policy/v1"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
 
 	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/events"
@@ -39,6 +41,7 @@ type GuardController struct {
 	readyzPort                         string
 	readyzEndpoint                     string
 	operandPodLabelSelector            labels.Selector
+	pdbUnhealthyPodEvictionPolicy      *v1.UnhealthyPodEvictionPolicyType
 
 	nodeLister corelisterv1.NodeLister
 	podLister  corelisterv1.PodLister
@@ -58,6 +61,7 @@ func NewGuardController(
 	operatorName string,
 	readyzPort string,
 	readyzEndpoint string,
+	pdbUnhealthyPodEvictionPolicy *v1.UnhealthyPodEvictionPolicyType,
 	kubeInformersForTargetNamespace informers.SharedInformerFactory,
 	kubeInformersClusterScoped informers.SharedInformerFactory,
 	operatorClient operatorv1helpers.StaticPodOperatorClient,
@@ -73,20 +77,29 @@ func NewGuardController(
 		return nil, fmt.Errorf("GuardController: operandPodLabelSelector cannot be empty")
 	}
 
+	// test any new UnhealthyPodEvictionPolicyType before adding them to the supported list
+	if !(pdbUnhealthyPodEvictionPolicy == nil ||
+		*pdbUnhealthyPodEvictionPolicy == v1.IfHealthyBudget ||
+		*pdbUnhealthyPodEvictionPolicy == v1.AlwaysAllow) {
+		return nil, fmt.Errorf("GuardController: only <nil>, %q and %q pdbUnhealthyPodEvictionPolicy values are supported", v1.IfHealthyBudget, v1.AlwaysAllow)
+
+	}
+
 	c := &GuardController{
-		targetNamespace:         targetNamespace,
-		operandPodLabelSelector: operandPodLabelSelector,
-		podResourcePrefix:       podResourcePrefix,
-		operatorName:            operatorName,
-		readyzPort:              readyzPort,
-		readyzEndpoint:          readyzEndpoint,
-		nodeLister:              kubeInformersClusterScoped.Core().V1().Nodes().Lister(),
-		podLister:               kubeInformersForTargetNamespace.Core().V1().Pods().Lister(),
-		podGetter:               podGetter,
-		pdbGetter:               pdbGetter,
-		pdbLister:               kubeInformersForTargetNamespace.Policy().V1().PodDisruptionBudgets().Lister(),
-		installerPodImageFn:     getInstallerPodImageFromEnv,
-		createConditionalFunc:   createConditionalFunc,
+		targetNamespace:               targetNamespace,
+		operandPodLabelSelector:       operandPodLabelSelector,
+		podResourcePrefix:             podResourcePrefix,
+		operatorName:                  operatorName,
+		readyzPort:                    readyzPort,
+		readyzEndpoint:                readyzEndpoint,
+		pdbUnhealthyPodEvictionPolicy: pdbUnhealthyPodEvictionPolicy,
+		nodeLister:                    kubeInformersClusterScoped.Core().V1().Nodes().Lister(),
+		podLister:                     kubeInformersForTargetNamespace.Core().V1().Pods().Lister(),
+		podGetter:                     podGetter,
+		pdbGetter:                     pdbGetter,
+		pdbLister:                     kubeInformersForTargetNamespace.Policy().V1().PodDisruptionBudgets().Lister(),
+		installerPodImageFn:           getInstallerPodImageFromEnv,
+		createConditionalFunc:         createConditionalFunc,
 	}
 
 	return factory.New().WithInformers(
@@ -222,14 +235,16 @@ func (c *GuardController) sync(ctx context.Context, syncCtx factory.SyncContext)
 		pdb := resourceread.ReadPodDisruptionBudgetV1OrDie(pdbTemplate)
 		pdb.ObjectMeta.Name = getGuardPDBName(c.podResourcePrefix)
 		pdb.ObjectMeta.Namespace = c.targetNamespace
+		pdb.Spec.UnhealthyPodEvictionPolicy = c.pdbUnhealthyPodEvictionPolicy
 		if len(nodes) > 1 {
-			minAvailable := intstr.FromInt(len(nodes) - 1)
+			minAvailable := intstr.FromInt32(int32(len(nodes)) - 1)
 			pdb.Spec.MinAvailable = &minAvailable
 		}
 
 		pdbObj, err := c.pdbLister.PodDisruptionBudgets(pdb.Namespace).Get(pdb.Name)
 		if err == nil {
-			if pdbObj.Spec.MinAvailable != pdb.Spec.MinAvailable {
+			if !ptr.Equal(pdbObj.Spec.UnhealthyPodEvictionPolicy, pdb.Spec.UnhealthyPodEvictionPolicy) ||
+				!ptr.Equal(pdbObj.Spec.MinAvailable, pdb.Spec.MinAvailable) {
 				_, _, err = resourceapply.ApplyPodDisruptionBudget(ctx, c.pdbGetter, syncCtx.Recorder(), pdb)
 				if err != nil {
 					klog.Errorf("Unable to apply PodDisruptionBudget changes: %v", err)
@@ -319,6 +334,10 @@ func (c *GuardController) sync(ctx context.Context, syncCtx factory.SyncContext)
 				}
 				if actual.Spec.Hostname != pod.Spec.Hostname {
 					klog.V(5).Infof("Guard Hostname changed, deleting %v so the guard can be re-created", pod.Name)
+					delete = true
+				}
+				if actual.Status.Phase != "" && actual.Status.Phase != corev1.PodPending && actual.Status.Phase != corev1.PodRunning {
+					klog.V(5).Infof("Pod phase is neither pending nor running, deleting %v so the guard can be re-created", pod.Name)
 					delete = true
 				}
 				if delete {

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/guard/manifests/guard-pod.yaml
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/guard/manifests/guard-pod.yaml
@@ -3,6 +3,8 @@ kind: Pod
 metadata:
   namespace: # Value set by operator
   name: # Value set by operator
+  annotations:
+    target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
   labels:
     app: guard
   ownerReferences: # Value set by operator

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/installerpod/cmd.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/installerpod/cmd.go
@@ -565,7 +565,7 @@ func (o *InstallOptions) getInstallerPodsOnThisNode(ctx context.Context) ([]*cor
 func (o *InstallOptions) installerPodNeedUUID() bool {
 	kubeletVersion, err := semver.Make(o.KubeletVersion)
 	if err != nil {
-		klog.Warningf("Failed to parse kubelet version %q to semver: %v (we will not generate pod UID)", err)
+		klog.Warningf("Failed to parse kubelet version %q to semver: %v (we will not generate pod UID)", o.KubeletVersion, err)
 		return false
 	}
 	// if we run kubelet older than 4.9, installer pods require UID generation

--- a/vendor/github.com/openshift/library-go/pkg/operator/v1helpers/helpers.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/v1helpers/helpers.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/util/retry"
+	"k8s.io/klog/v2"
 
 	"github.com/ghodss/yaml"
 
@@ -206,7 +207,7 @@ func UpdateStaticPodStatus(ctx context.Context, client StaticPodOperatorClient, 
 		if err != nil {
 			return err
 		}
-
+		klog.V(2).Infof("status.LatestAvailableRevision: %v, resourceVersion: %v", oldStatus.LatestAvailableRevision, resourceVersion)
 		newStatus := oldStatus.DeepCopy()
 		for _, update := range updateFuncs {
 			if err := update(newStatus); err != nil {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -269,7 +269,7 @@ github.com/openshift/client-go/route/applyconfigurations/route/v1
 github.com/openshift/client-go/route/clientset/versioned
 github.com/openshift/client-go/route/clientset/versioned/scheme
 github.com/openshift/client-go/route/clientset/versioned/typed/route/v1
-# github.com/openshift/library-go v0.0.0-20231017173800-126f85ed0cc7
+# github.com/openshift/library-go v0.0.0-20231128084459-0dbbc2c74004
 ## explicit; go 1.20
 github.com/openshift/library-go/pkg/assets
 github.com/openshift/library-go/pkg/authorization/hardcodedauthorizer


### PR DESCRIPTION
- revision_controller: be more verbose about LatestAvailableRevision and resourceVersion
- add pdbUnhealthyPodEvictionPolicy option to a GuardController
- guard: add workload partitioning annotation