### PR TITLE
don't apply configmap, use actual create

### DIFF
--- a/vendor/github.com/openshift/library-go/pkg/operator/revisioncontroller/revision_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/revisioncontroller/revision_controller.go
@@ -89,10 +89,12 @@ func (c RevisionController) createRevisionIfNeeded(ctx context.Context, recorder
 
 	// check to make sure that the latestRevision has the exact content we expect.  No mutation here, so we start creating the next Revision only when it is required
 	if isLatestRevisionCurrent {
+		recorder.Eventf("LatestRevision", "returning early %d triggered by %q", isLatestRevisionCurrent, reason)
 		return false, nil
 	}
 
 	nextRevision := latestAvailableRevision + 1
+	recorder.Eventf("StartingNewRevision", "new revision %d triggered by %q", nextRevision, reason)
 	createdNewRevision, err := c.createNewRevision(ctx, recorder, nextRevision, reason)
 	if  err != nil {
 		cond := operatorv1.OperatorCondition{


### PR DESCRIPTION
response to https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/periodic-ci-openshift-multiarch-master-nightly-4.15-ocp-e2e-ovn-remote-libvirt-s390x/1731508664730128384/artifacts/ocp-e2e-ovn-remote-libvirt-s390x/gather-libvirt/artifacts/pods/openshift-kube-scheduler-operator_openshift-kube-scheduler-operator-85d8655584-2w2tk_kube-scheduler-operator-container_previous.log

> new revision 5 triggered by

twice

the existing flow is
1. cache says we have a change
2. event saying we're making a revision happens
3. we apply configmap for revision.  This does a create
4. data is cloned for revision
5. something triggers the controller
6. cache isn't up to date
7. event says we're making a revision happens
8. we apply configmap and there is no change, so no event.
9. data is cloned for a configmap that should never be changed
10. race is indicated

the new flow will return nil (no work to do) at step 8.

/assign @ingvagabund 