### PR TITLE
WIP: Change YAML style of scheduler-kubeconfig from human to compact JSON

### DIFF
--- a/bindata/assets/kube-scheduler/kubeconfig-cm.yaml
+++ b/bindata/assets/kube-scheduler/kubeconfig-cm.yaml
@@ -4,23 +4,4 @@ metadata:
   name: scheduler-kubeconfig
   namespace: openshift-kube-scheduler
 data:
-  kubeconfig: |
-    apiVersion: v1
-    clusters:
-      - cluster:
-          certificate-authority: /etc/kubernetes/static-pod-resources/configmaps/serviceaccount-ca/ca-bundle.crt
-          server: $LB_INT_URL
-        name: lb-int
-    contexts:
-      - context:
-          cluster: lb-int
-          user: kube-scheduler
-        name: kube-scheduler
-    current-context: kube-scheduler
-    kind: Config
-    preferences: {}
-    users:
-      - name: kube-scheduler
-        user:
-          client-certificate: /etc/kubernetes/static-pod-certs/secrets/kube-scheduler-client-cert-key/tls.crt
-          client-key: /etc/kubernetes/static-pod-certs/secrets/kube-scheduler-client-cert-key/tls.key
+  kubeconfig: '{"apiVersion":"v1","clusters":[{"cluster":{"certificate-authority":"/etc/kubernetes/static-pod-resources/configmaps/serviceaccount-ca/ca-bundle.crt","server":"$LB_INT_URL"},"name":"lb-int"}],"contexts":[{"context":{"cluster":"lb-int","user":"kube-scheduler"},"name":"kube-scheduler"}],"current-context":"kube-scheduler","kind":"Config","preferences":{},"users":[{"name":"kube-scheduler","user":{"client-certificate":"/etc/kubernetes/static-pod-certs/secrets/kube-scheduler-client-cert-key/tls.crt","client-key":"/etc/kubernetes/static-pod-certs/secrets/kube-scheduler-client-cert-key/tls.key"}}]}'

--- a/pkg/operator/targetconfigcontroller/targetconfigcontroller_test.go
+++ b/pkg/operator/targetconfigcontroller/targetconfigcontroller_test.go
@@ -192,26 +192,7 @@ func Test_manageKubeSchedulerConfigMap_v311_00_to_latest(t *testing.T) {
 	}
 }
 
-var defaultKubeconfigData = `apiVersion: v1
-clusters:
-  - cluster:
-      certificate-authority: /etc/kubernetes/static-pod-resources/configmaps/serviceaccount-ca/ca-bundle.crt
-      server: https://127.0.0.1:443
-    name: lb-int
-contexts:
-  - context:
-      cluster: lb-int
-      user: kube-scheduler
-    name: kube-scheduler
-current-context: kube-scheduler
-kind: Config
-preferences: {}
-users:
-  - name: kube-scheduler
-    user:
-      client-certificate: /etc/kubernetes/static-pod-certs/secrets/kube-scheduler-client-cert-key/tls.crt
-      client-key: /etc/kubernetes/static-pod-certs/secrets/kube-scheduler-client-cert-key/tls.key
-`
+var defaultKubeconfigData = `{"apiVersion":"v1","clusters":[{"cluster":{"certificate-authority":"/etc/kubernetes/static-pod-resources/configmaps/serviceaccount-ca/ca-bundle.crt","server":"https://127.0.0.1:443"},"name":"lb-int"}],"contexts":[{"context":{"cluster":"lb-int","user":"kube-scheduler"},"name":"kube-scheduler"}],"current-context":"kube-scheduler","kind":"Config","preferences":{},"users":[{"name":"kube-scheduler","user":{"client-certificate":"/etc/kubernetes/static-pod-certs/secrets/kube-scheduler-client-cert-key/tls.crt","client-key":"/etc/kubernetes/static-pod-certs/secrets/kube-scheduler-client-cert-key/tls.key"}}]}`
 
 var configMapKubeConfigCMDefault = &corev1.ConfigMap{
 	TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "ConfigMap"},


### PR DESCRIPTION
(This is currently a WIP PR suggestion)

# Background

The `scheduler-kubeconfig` configmap managed by this operator contains a
YAML formatted `kubeconfig` string. As part of a particular novel form
of OCP deployment (image based upgrade/installation), we have to
programmatically modify the `server:` entry in that kubeconfig. This is
easily done by parsing the YAML, editing the server entry and
serializing the YAML back into the configmap.

# Issue

Every YAML serializer has its own opinions of what YAML should look
like. When we perform the procedure described above, we get a kubeconfig
that's slightly different than what this operator outputs (different
indentation, different quoting decisions). As a result, it eventually
causes the kube-scheduler-operator to issue a new revision of the
scheduler. Rolling out the new revision takes a few minutes, which we
would prefer to avoid.

# Solution

In order to solve this we suggest the change in this commit which would
be to format this kubeconfig as unopinionated compact JSON as opposed to
human readable YAML

# Alternative solutions

We could have a textual "search-and-replace" for the `server:` entry in
our code, but we would prefer to do it right by properly parsing,
editing then serializing it.