### PR TITLE
OCPBUGS-45724: Updating ose-cluster-kube-scheduler-operator-container image to be consistent with ART for 4.19

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-9-release-golang-1.22-openshift-4.18
+  tag: rhel-9-release-golang-1.23-openshift-4.19

--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -1,9 +1,9 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.18 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.23-openshift-4.19 AS builder
 WORKDIR /go/src/github.com/openshift/cluster-kube-scheduler-operator
 COPY . .
 RUN make build --warn-undefined-variables
 
-FROM registry.ci.openshift.org/ocp/4.18:base-rhel9
+FROM registry.ci.openshift.org/ocp/4.19:base-rhel9
 RUN mkdir -p /usr/share/bootkube/manifests/bootstrap-manifests/ /usr/share/bootkube/manifests/config/ /usr/share/bootkube/manifests/manifests/
 COPY --from=builder /go/src/github.com/openshift/cluster-kube-scheduler-operator/bindata/bootkube/bootstrap-manifests /usr/share/bootkube/manifests/bootstrap-manifests/
 COPY --from=builder /go/src/github.com/openshift/cluster-kube-scheduler-operator/bindata/bootkube/config /usr/share/bootkube/manifests/config/

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/cluster-kube-scheduler-operator
 
-go 1.22.1
+go 1.23.2
 
 require (
 	github.com/blang/semver/v4 v4.0.0


### PR DESCRIPTION
Reconciling with https://github.com/openshift/ocp-build-data/tree/a39508c86497b4e5e463d7b2c78e51e577be9e7d/images/ose-cluster-kube-scheduler-operator.yml

Rebasing https://github.com/openshift/cluster-kube-scheduler-operator/pull/553.