### PR TITLE
OCPSTRAT-2001: Add readOnlyRootFilesystem to kube-scheduler-operator

### DIFF
--- a/manifests/0000_25_kube-scheduler-operator_06_deployment.yaml
+++ b/manifests/0000_25_kube-scheduler-operator_06_deployment.yaml
@@ -35,6 +35,7 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             drop: ["ALL"]
+          readOnlyRootFilesystem: true
         image: docker.io/openshift/origin-cluster-kube-scheduler-operator:v4.0
         imagePullPolicy: IfNotPresent
         command: ["cluster-kube-scheduler-operator", "operator"]
@@ -45,6 +46,8 @@ spec:
             memory: 50Mi
             cpu: 10m
         volumeMounts:
+        - mountPath: /tmp
+          name: tmp
         - mountPath: /var/run/configmaps/config
           name: config
         - mountPath: /var/run/secrets/serving-cert
@@ -67,6 +70,8 @@ spec:
               fieldPath: metadata.name
         terminationMessagePolicy: FallbackToLogsOnError
       volumes:
+      - name: tmp
+        emptyDir: {}
       - name: serving-cert
         secret:
           secretName: kube-scheduler-operator-serving-cert


### PR DESCRIPTION
Fix missing readOnlyRootFilesystem security context in the openshift-kube-scheduler-operator deployment.

This completes the work from PR #564 which added readOnlyRootFilesystem to the kube-scheduler pods, but missed the operator pod itself.

Changes:
- Add readOnlyRootFilesystem: true to container securityContext
- Add /tmp volume mount for temporary files
- Add tmp emptyDir volume

Fixes test failure:
'pod openshift-kube-scheduler-operator does not have readOnlyRootFilesystem'