### PR TITLE
use safer cipherSuites

### DIFF
--- a/manifests/0000_25_kube-scheduler-operator_03_configmap.yaml
+++ b/manifests/0000_25_kube-scheduler-operator_03_configmap.yaml
@@ -12,3 +12,12 @@ data:
   config.yaml: |
     apiVersion: operator.openshift.io/v1
     kind: GenericOperatorConfig
+    servingInfo:
+      cipherSuites:
+      - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+      - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+      - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+      - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+      - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
+      - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+      minTLSVersion: VersionTLS12


### PR DESCRIPTION
As the `openshift-kube-scheduler-operator` log shows it uses insecure cipher suites:

```
kubectl  logs -n openshift-kube-scheduler-operator openshift-kube-scheduler-operator-6bbcd855d5-5qxw4 

I0707 04:28:37.991198       1 cmd.go:241] Using service-serving-cert provided certificates
I0707 04:28:37.991323       1 leaderelection.go:122] The leader election gives 4 retries and allows for 30s of clock skew. The kube-apiserver downtime tolerance is 78s. Worst non-graceful lease acquisition is 2m43s. Worst graceful lease acquisition is {26s}.
I0707 04:28:37.991679       1 observer_polling.go:159] Starting file observer
I0707 04:28:38.783907       1 secure_serving.go:57] Forcing use of http/1.1 only
W0707 04:28:38.783934       1 secure_serving.go:69] Use of insecure cipher 'TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256' detected.
W0707 04:28:38.783939       1 secure_serving.go:69] Use of insecure cipher 'TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256' detected.
I0707 04:28:38.786999       1 leaderelection.go:250] attempting to acquire leader lease openshift-kube-scheduler-operator/openshift-cluster-kube-scheduler-operator-lock...
I0707 04:28:38.787258       1 requestheader_controller.go:169] Starting RequestHeaderAuthRequestController
```
maybe the ceo should run in secure cipher
