### PR TITLE
CNTRLPLANE-1544: Enable user namespace for the operator

### DIFF
--- a/manifests/0000_25_kube-scheduler-operator_06_deployment.yaml
+++ b/manifests/0000_25_kube-scheduler-operator_06_deployment.yaml
@@ -9,6 +9,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/single-node-developer: "true"
+    openshift.io/required-scc: restricted-v3
 spec:
   replicas: 1
   selector:
@@ -22,9 +23,12 @@ spec:
       labels:
         app: openshift-kube-scheduler-operator
     spec:
+      hostUsers: false
       securityContext:
         runAsNonRoot: true
-        runAsUser: 65534
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
         seccompProfile:
           type: RuntimeDefault    
       automountServiceAccountToken: false


### PR DESCRIPTION
The operator now uses `hostUsers: false` in the associated deployment.
All relevant user and group IDs are set to 1000.