### PR TITLE
CNTRLPLANE-1544: manifests: Align user namespaces for the operator

### DIFF
--- a/manifests/0000_25_kube-scheduler-operator_06_deployment.yaml
+++ b/manifests/0000_25_kube-scheduler-operator_06_deployment.yaml
@@ -9,7 +9,6 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/single-node-developer: "true"
-    openshift.io/required-scc: restricted-v3
 spec:
   replicas: 1
   selector:


### PR DESCRIPTION
Actually the operator namespace is not being processed by SCC admission
due to the run-level annotation. That's why we need to set everything
manually and remove required-scc annotation.

Aligns #580 