### PR TITLE
OCPBUGS-65503: manifests: Expand related objects in clusteroperator

### DIFF
--- a/manifests/0000_25_kube-scheduler-operator_07_clusteroperator.yaml
+++ b/manifests/0000_25_kube-scheduler-operator_07_clusteroperator.yaml
@@ -36,3 +36,6 @@ status:
     - group: controlplane.operator.openshift.io
       resource: podnetworkconnectivitychecks
       namespace: openshift-kube-scheduler
+    - group: "rbac.authorization.k8s.io"
+      name: "system:openshift:operator:cluster-kube-scheduler-operator"
+      resource: "clusterrolebindings"

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -194,6 +194,7 @@ func RunOperator(ctx context.Context, cc *controllercmd.ControllerContext) error
 			{Resource: "namespaces", Name: operatorclient.TargetNamespace},
 			{Resource: "namespaces", Name: "openshift-kube-scheduler-operator"},
 			{Group: "controlplane.operator.openshift.io", Resource: "podnetworkconnectivitychecks", Namespace: "openshift-kube-apiserver"},
+			{Group: "rbac.authorization.k8s.io", Resource: "clusterrolebindings", Name: "system:openshift:operator:cluster-kube-scheduler-operator"},
 		},
 		configClient.ConfigV1(),
 		configInformers.Config().V1().ClusterOperators(),


### PR DESCRIPTION
Add system:openshift:operator:kube-scheduler-operator ClusterRoleBinding to the list of related objects.