### PR TITLE
OCPBUGS-74591: pkg/operator: Fix wrong ClusterOperator name

### DIFF
--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -150,7 +150,7 @@ func RunOperator(ctx context.Context, cc *controllercmd.ControllerContext) error
 
 	// don't change any versions until we sync
 	versionRecorder := status.NewVersionGetter()
-	clusterOperator, err := configClient.ConfigV1().ClusterOperators().Get(ctx, "kube-scheduler-operator", metav1.GetOptions{})
+	clusterOperator, err := configClient.ConfigV1().ClusterOperators().Get(ctx, "kube-scheduler", metav1.GetOptions{})
 	if err != nil && !apierrors.IsNotFound(err) {
 		return err
 	}


### PR DESCRIPTION
The right name is `kube-scheduler`, not `kube-scheduler-operator`.

You can see the list of operators on [CI](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_cluster-kube-scheduler-operator/593/pull-ci-openshift-cluster-kube-scheduler-operator-main-e2e-aws-operator/2009286307011891200/artifacts/e2e-aws-operator/gather-extra/artifacts/inspect/cluster-scoped-resources/config.openshift.io/clusteroperators/).