### PR TITLE
WIP: NO-JIRA: dep: Update library-go to improve logging

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -119,3 +119,6 @@ require (
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.0 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
+
+// tchap:correct-certrotation-annotation-update-logging
+replace github.com/openshift/library-go => github.com/tchap/library-go v0.0.0-20260113154628-16bafb54c851

--- a/go.sum
+++ b/go.sum
@@ -153,8 +153,6 @@ github.com/openshift/build-machinery-go v0.0.0-20250530140348-dc5b2804eeee h1:+S
 github.com/openshift/build-machinery-go v0.0.0-20250530140348-dc5b2804eeee/go.mod h1:8jcm8UPtg2mCAsxfqKil1xrmRMI3a+XU2TZ9fF8A7TE=
 github.com/openshift/client-go v0.0.0-20251015124057-db0dee36e235 h1:9JBeIXmnHlpXTQPi7LPmu1jdxznBhAE7bb1K+3D8gxY=
 github.com/openshift/client-go v0.0.0-20251015124057-db0dee36e235/go.mod h1:L49W6pfrZkfOE5iC1PqEkuLkXG4W0BX4w8b+L2Bv7fM=
-github.com/openshift/library-go v0.0.0-20260108135436-db8dbd64c462 h1:zX9Od4Jg8sVmwQLwk6Vd+BX7tcyC/462FVvDdzHEPPk=
-github.com/openshift/library-go v0.0.0-20260108135436-db8dbd64c462/go.mod h1:nIzWQQE49XbiKizVnVOip9CEB7HJ0hoJwNi3g3YKnKc=
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde/go.mod h1:nZgzbfBr3hhjoZnS66nKrHmduYNpc34ny7RK4z5/HM0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -200,6 +198,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/tchap/library-go v0.0.0-20260113154628-16bafb54c851 h1:CQeg2j6LkEZPnV6rcC+ydLXExm1R2VSE0+VdmpUgWLg=
+github.com/tchap/library-go v0.0.0-20260113154628-16bafb54c851/go.mod h1:nIzWQQE49XbiKizVnVOip9CEB7HJ0hoJwNi3g3YKnKc=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20220101234140-673ab2c3ae75 h1:6fotK7otjonDflCTK0BCfls4SPy3NcCVb5dqqmbRknE=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20220101234140-673ab2c3ae75/go.mod h1:KO6IkyS8Y3j8OdNO85qEYBsRPuteD+YciPomcXdrMnk=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=

--- a/vendor/github.com/openshift/library-go/pkg/operator/certrotation/annotations.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/certrotation/annotations.go
@@ -1,10 +1,8 @@
 package certrotation
 
 import (
-	"github.com/google/go-cmp/cmp"
 	"github.com/openshift/api/annotations"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/klog/v2"
 )
 
 const (
@@ -48,44 +46,30 @@ func (a AdditionalAnnotations) EnsureTLSMetadataUpdate(meta *metav1.ObjectMeta) 
 		meta.Annotations = make(map[string]string)
 	}
 	if len(a.JiraComponent) > 0 && meta.Annotations[annotations.OpenShiftComponent] != a.JiraComponent {
-		diff := cmp.Diff(meta.Annotations[annotations.OpenShiftComponent], a.JiraComponent)
-		klog.V(2).Infof("Updating %q annotation for %s/%s, diff: %s", annotations.OpenShiftComponent, meta.Namespace, meta.Name, diff)
 		meta.Annotations[annotations.OpenShiftComponent] = a.JiraComponent
 		modified = true
 	}
 	if len(a.Description) > 0 && meta.Annotations[annotations.OpenShiftDescription] != a.Description {
-		diff := cmp.Diff(meta.Annotations[annotations.OpenShiftDescription], a.Description)
-		klog.V(2).Infof("Updating %q annotation for %s/%s, diff: %s", annotations.OpenShiftDescription, meta.Namespace, meta.Name, diff)
 		meta.Annotations[annotations.OpenShiftDescription] = a.Description
 		modified = true
 	}
 	if len(a.TestName) > 0 && meta.Annotations[CertificateTestNameAnnotation] != a.TestName {
-		diff := cmp.Diff(meta.Annotations[CertificateTestNameAnnotation], a.TestName)
-		klog.V(2).Infof("Updating %q annotation for %s/%s, diff: %s", CertificateTestNameAnnotation, meta.Name, meta.Namespace, diff)
 		meta.Annotations[CertificateTestNameAnnotation] = a.TestName
 		modified = true
 	}
 	if len(a.AutoRegenerateAfterOfflineExpiry) > 0 && meta.Annotations[CertificateAutoRegenerateAfterOfflineExpiryAnnotation] != a.AutoRegenerateAfterOfflineExpiry {
-		diff := cmp.Diff(meta.Annotations[CertificateAutoRegenerateAfterOfflineExpiryAnnotation], a.AutoRegenerateAfterOfflineExpiry)
-		klog.V(2).Infof("Updating %q annotation for %s/%s, diff: %s", CertificateAutoRegenerateAfterOfflineExpiryAnnotation, meta.Namespace, meta.Name, diff)
 		meta.Annotations[CertificateAutoRegenerateAfterOfflineExpiryAnnotation] = a.AutoRegenerateAfterOfflineExpiry
 		modified = true
 	}
 	if len(a.NotBefore) > 0 && meta.Annotations[CertificateNotBeforeAnnotation] != a.NotBefore {
-		diff := cmp.Diff(meta.Annotations[CertificateNotBeforeAnnotation], a.NotBefore)
-		klog.V(2).Infof("Updating %q annotation for %s/%s, diff: %s", CertificateNotBeforeAnnotation, meta.Name, meta.Namespace, diff)
 		meta.Annotations[CertificateNotBeforeAnnotation] = a.NotBefore
 		modified = true
 	}
 	if len(a.NotAfter) > 0 && meta.Annotations[CertificateNotAfterAnnotation] != a.NotAfter {
-		diff := cmp.Diff(meta.Annotations[CertificateNotAfterAnnotation], a.NotAfter)
-		klog.V(2).Infof("Updating %q annotation for %s/%s, diff: %s", CertificateNotAfterAnnotation, meta.Name, meta.Namespace, diff)
 		meta.Annotations[CertificateNotAfterAnnotation] = a.NotAfter
 		modified = true
 	}
 	if len(a.RefreshPeriod) > 0 && meta.Annotations[CertificateRefreshPeriodAnnotation] != a.RefreshPeriod {
-		diff := cmp.Diff(meta.Annotations[CertificateRefreshPeriodAnnotation], a.RefreshPeriod)
-		klog.V(2).Infof("Updating %q annotation for %s/%s, diff: %s", CertificateRefreshPeriodAnnotation, meta.Name, meta.Namespace, diff)
 		meta.Annotations[CertificateRefreshPeriodAnnotation] = a.RefreshPeriod
 		modified = true
 	}

--- a/vendor/github.com/openshift/library-go/pkg/operator/certrotation/target.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/certrotation/target.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -135,7 +137,14 @@ func (c RotatedSelfSignedCertKeySecret) EnsureTargetCertKeyPair(ctx context.Cont
 		if err != nil {
 			return nil, err
 		}
-		klog.V(2).Infof("Created secret %s/%s", actualTargetCertKeyPairSecret.Namespace, actualTargetCertKeyPairSecret.Name)
+
+		if klog.V(2).Enabled() {
+			klog.V(2).Infof("Created secret %s/%s", actualTargetCertKeyPairSecret.Namespace, actualTargetCertKeyPairSecret.Name)
+			if diff := cmp.Diff(nil, actualTargetCertKeyPairSecret.Annotations); len(diff) > 0 {
+				klog.V(2).Infof("Secret %s/%s annotations diff: %s", actualTargetCertKeyPairSecret.Namespace, actualTargetCertKeyPairSecret.Name, diff)
+			}
+		}
+
 		targetCertKeyPairSecret = actualTargetCertKeyPairSecret
 	} else if updateRequired {
 		actualTargetCertKeyPairSecret, err := c.Client.Secrets(c.Namespace).Update(ctx, targetCertKeyPairSecret, metav1.UpdateOptions{})
@@ -147,7 +156,14 @@ func (c RotatedSelfSignedCertKeySecret) EnsureTargetCertKeyPair(ctx context.Cont
 		if err != nil {
 			return nil, err
 		}
-		klog.V(2).Infof("Updated secret %s/%s", actualTargetCertKeyPairSecret.Namespace, actualTargetCertKeyPairSecret.Name)
+
+		if klog.V(2).Enabled() {
+			klog.V(2).Infof("Updated secret %s/%s", actualTargetCertKeyPairSecret.Namespace, actualTargetCertKeyPairSecret.Name)
+			if diff := cmp.Diff(originalTargetCertKeyPairSecret.Annotations, actualTargetCertKeyPairSecret.Annotations); len(diff) > 0 {
+				klog.V(2).Infof("Secret %s/%s annotations diff: %s", actualTargetCertKeyPairSecret.Namespace, actualTargetCertKeyPairSecret.Name, diff)
+			}
+		}
+
 		targetCertKeyPairSecret = actualTargetCertKeyPairSecret
 	}
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -296,7 +296,7 @@ github.com/openshift/client-go/route/applyconfigurations/route/v1
 github.com/openshift/client-go/route/clientset/versioned
 github.com/openshift/client-go/route/clientset/versioned/scheme
 github.com/openshift/client-go/route/clientset/versioned/typed/route/v1
-# github.com/openshift/library-go v0.0.0-20260108135436-db8dbd64c462
+# github.com/openshift/library-go v0.0.0-20260108135436-db8dbd64c462 => github.com/tchap/library-go v0.0.0-20260113154628-16bafb54c851
 ## explicit; go 1.24.0
 github.com/openshift/library-go/pkg/apiserver/jsonpatch
 github.com/openshift/library-go/pkg/assets
@@ -1494,3 +1494,4 @@ sigs.k8s.io/structured-merge-diff/v6/value
 # sigs.k8s.io/yaml v1.6.0
 ## explicit; go 1.22
 sigs.k8s.io/yaml
+# github.com/openshift/library-go => github.com/tchap/library-go v0.0.0-20260113154628-16bafb54c851


### PR DESCRIPTION
Depends on https://github.com/openshift/library-go/pull/2078

It's visible the extra log entries are not present on [CI](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_cluster-kube-scheduler-operator/598/pull-ci-openshift-cluster-kube-scheduler-operator-main-e2e-aws-operator/2011104179719770112/artifacts/e2e-aws-operator/gather-extra/artifacts/pods/openshift-kube-scheduler-operator_openshift-kube-scheduler-operator-7948b5d795-jpv28_kube-scheduler-operator-container.log)