### PR TITLE
OCPBUGS-65941: Add OPERATOR_IMAGE_VERSION to recovery container

### DIFF
--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -138,6 +138,7 @@ func RunOperator(ctx context.Context, cc *controllercmd.ControllerContext) error
 	targetConfigController := targetconfigcontroller.NewTargetConfigController(
 		os.Getenv("IMAGE"),
 		os.Getenv("OPERATOR_IMAGE"),
+		os.Getenv("OPERATOR_IMAGE_VERSION"),
 		featureGates,
 		operatorClient,
 		kubeInformersForNamespaces,

--- a/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
+++ b/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
@@ -42,6 +42,7 @@ import (
 type TargetConfigController struct {
 	targetImagePullSpec   string
 	operatorImagePullSpec string
+	operatorImageVersion  string
 	featureGates          featuregates.FeatureGate
 	operatorClient        v1helpers.StaticPodOperatorClient
 	kubeClient            kubernetes.Interface
@@ -51,7 +52,7 @@ type TargetConfigController struct {
 }
 
 func NewTargetConfigController(
-	targetImagePullSpec, operatorImagePullSpec string,
+	targetImagePullSpec, operatorImagePullSpec, operatorImageVersion string,
 	featureGates featuregates.FeatureGate,
 	operatorConfigClient v1helpers.OperatorClient,
 	kubeInformersForNamespaces v1helpers.KubeInformersForNamespaces,
@@ -63,6 +64,7 @@ func NewTargetConfigController(
 	c := &TargetConfigController{
 		targetImagePullSpec:   targetImagePullSpec,
 		operatorImagePullSpec: operatorImagePullSpec,
+		operatorImageVersion:  operatorImageVersion,
 		featureGates:          featureGates,
 		kubeClient:            kubeClient,
 		configMapLister:       kubeInformersForNamespaces.ConfigMapLister(),
@@ -139,7 +141,7 @@ func createTargetConfigController_v311_00_to_latest(ctx context.Context, syncCtx
 	if err != nil {
 		errors = append(errors, fmt.Errorf("%q: %v", "configmap/scheduler-kubeconfig", err))
 	}
-	_, _, err = managePod_v311_00_to_latest(ctx, c.featureGates, c.kubeClient.CoreV1(), c.kubeClient.CoreV1(), syncCtx.Recorder(), operatorSpec, c.targetImagePullSpec, c.operatorImagePullSpec, c.configSchedulerLister)
+	_, _, err = managePod_v311_00_to_latest(ctx, c.featureGates, c.kubeClient.CoreV1(), c.kubeClient.CoreV1(), syncCtx.Recorder(), operatorSpec, c.targetImagePullSpec, c.operatorImagePullSpec, c.operatorImageVersion, c.configSchedulerLister)
 	if err != nil {
 		errors = append(errors, fmt.Errorf("%q: %v", "configmap/kube-scheduler-pod", err))
 	}
@@ -212,7 +214,7 @@ func manageKubeSchedulerConfigMap_v311_00_to_latest(ctx context.Context, feature
 	return resourceapply.ApplyConfigMap(ctx, client, recorder, requiredConfigMap)
 }
 
-func managePod_v311_00_to_latest(ctx context.Context, featureGates featuregates.FeatureGate, configMapsGetter corev1client.ConfigMapsGetter, secretsGetter corev1client.SecretsGetter, recorder events.Recorder, operatorSpec *operatorv1.StaticPodOperatorSpec, imagePullSpec, operatorImagePullSpec string, configSchedulerLister configlistersv1.SchedulerLister) (*corev1.ConfigMap, bool, error) {
+func managePod_v311_00_to_latest(ctx context.Context, featureGates featuregates.FeatureGate, configMapsGetter corev1client.ConfigMapsGetter, secretsGetter corev1client.SecretsGetter, recorder events.Recorder, operatorSpec *operatorv1.StaticPodOperatorSpec, imagePullSpec, operatorImagePullSpec, operatorImageVersion string, configSchedulerLister configlistersv1.SchedulerLister) (*corev1.ConfigMap, bool, error) {
 	required := resourceread.ReadPodV1OrDie(bindata.MustAsset("assets/kube-scheduler/pod.yaml"))
 	images := map[string]string{
 		"${IMAGE}":          imagePullSpec,
@@ -303,6 +305,18 @@ func managePod_v311_00_to_latest(ctx context.Context, featureGates featuregates.
 		klog.Warningf("failed on getting arguments from UnsupportedConfigOverrides config due to %v", err)
 	} else if len(unsupportedArgs) > 0 {
 		required.Spec.Containers[0].Args = append(required.Spec.Containers[0].Args, unsupportedArgs...)
+	}
+
+	// Set operator image version. This is currently only used to always deploy the pod during upgrade,
+	// causing Progressing=True to be shown as expected.
+	for i, container := range required.Spec.Containers {
+		if container.Name != "kube-scheduler-recovery-controller" {
+			continue
+		}
+		required.Spec.Containers[i].Env = append(container.Env, corev1.EnvVar{
+			Name:  "OPERATOR_IMAGE_VERSION",
+			Value: operatorImageVersion,
+		})
 	}
 
 	configMap := resourceread.ReadConfigMapV1OrDie(bindata.MustAsset("assets/kube-scheduler/pod-cm.yaml"))

--- a/pkg/operator/targetconfigcontroller/targetconfigcontroller_test.go
+++ b/pkg/operator/targetconfigcontroller/targetconfigcontroller_test.go
@@ -485,6 +485,7 @@ func TestManagePodToLatest(t *testing.T) {
 				&scenario.operator.Spec.StaticPodOperatorSpec,
 				"CaptainAmerica",
 				"Piper",
+				"0.0.1-snaphot",
 				configSchedulerLister)
 
 			// validate
@@ -761,6 +762,7 @@ func TestManagePod_TLSConfiguration(t *testing.T) {
 			targetConfigController := NewTargetConfigController(
 				"test-image",
 				"test-operator-image",
+				"0.0.1-snaphot",
 				featuregates.NewFeatureGate(nil, nil),
 				fakeOperatorClient,
 				kubeInformersForNamespaces,

--- a/pkg/operator/targetconfigcontroller/testdata/ks_pod_scenario_1.yaml
+++ b/pkg/operator/targetconfigcontroller/testdata/ks_pod_scenario_1.yaml
@@ -135,6 +135,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: OPERATOR_IMAGE_VERSION
+          value: "0.0.1-snaphot"
       resources:
         requests:
           cpu: 5m

--- a/pkg/operator/targetconfigcontroller/testdata/ks_pod_scenario_2.yaml
+++ b/pkg/operator/targetconfigcontroller/testdata/ks_pod_scenario_2.yaml
@@ -136,6 +136,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: OPERATOR_IMAGE_VERSION
+          value: "0.0.1-snaphot"
       resources:
         requests:
           cpu: 5m

--- a/pkg/operator/targetconfigcontroller/testdata/ks_pod_scenario_3.yaml
+++ b/pkg/operator/targetconfigcontroller/testdata/ks_pod_scenario_3.yaml
@@ -137,6 +137,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: OPERATOR_IMAGE_VERSION
+          value: "0.0.1-snaphot"
       resources:
         requests:
           cpu: 5m


### PR DESCRIPTION
Set `OPERATOR_IMAGE_VERSION` environment variable on the recovery container in the operand pod so that the pod is redeployed during upgrade and we can see `Progressing=True`.

This does not make too much sense, but it's required for the operator to show `Progressing=True` during upgrade, and this is the way to achieve this. Other operators like KCMO work in a similar way, although there the value is actually being used.