### PR TITLE
NO-JIRA: pkg/operator: Fix StaticResourceController name

### DIFF
--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -115,7 +115,7 @@ func RunOperator(ctx context.Context, cc *controllercmd.ControllerContext) error
 	)
 
 	staticResourceController := staticresourcecontroller.NewStaticResourceController(
-		"KubeControllerManagerStaticResources",
+		"KubeSchedulerStaticResources",
 		bindata.Asset,
 		[]string{
 			"assets/kube-scheduler/ns.yaml",


### PR DESCRIPTION
This is a copy-paste error, fixing from `KubeControllerManagerStaticResources` to `KubeSchedulerStaticResources`.