### PR TITLE
add e2e test for networkpolicy

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,3 +365,22 @@ Tests are tagged with the following labels to determine their execution suite:
 - **`[PreferredHost][Serial]`** - Tests that verify KubeScheduler communication with kube-apiserver over preferred host
 
 For more information about the OTE framework, see the [openshift-tests-extension documentation](https://github.com/openshift-eng/openshift-tests-extension).
+
+### Running NetworkPolicy Tests
+
+To run NetworkPolicy tests directly using `go test`:
+
+```bash
+# Set KUBECONFIG
+export KUBECONFIG=/path/to/your/kubeconfig
+
+# Run all NetworkPolicy tests
+go test ./test/e2e -v --ginkgo.focus="NetworkPolicy" -timeout 30m
+
+# Run specific tests
+go test ./test/e2e -v --ginkgo.focus="should ensure kube scheduler NetworkPolicies are defined" -timeout 10m
+go test ./test/e2e -v --ginkgo.focus="should restore kube scheduler NetworkPolicies" -timeout 30m
+go test ./test/e2e -v --ginkgo.focus="should enforce generic NetworkPolicies" -timeout 10m
+go test ./test/e2e -v --ginkgo.focus="should enforce kube scheduler NetworkPolicies" -timeout 10m
+```
+

--- a/test/e2e/network_policy.go
+++ b/test/e2e/network_policy.go
@@ -1,0 +1,498 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+
+	test "github.com/openshift/cluster-kube-scheduler-operator/test/library"
+)
+
+const (
+	schedulerNamespace          = "openshift-kube-scheduler"
+	schedulerOperatorNamespace  = "openshift-kube-scheduler-operator"
+	defaultDenyAllPolicyName    = "default-deny-all"
+	schedulerPolicyName         = "installer-pruner"
+	schedulerOperatorPolicyName = "kube-scheduler-operator"
+)
+
+var _ = g.Describe("[sig-scheduling] kube scheduler operator", func() {
+	g.It("[NetworkPolicy][Disruptive][Serial] should ensure kube scheduler NetworkPolicies are defined", func() {
+		testSchedulerNetworkPolicies()
+	})
+	g.It("[NetworkPolicy][Disruptive][Serial] should restore kube scheduler NetworkPolicies after delete or mutation[Timeout:30m]", func() {
+		testSchedulerNetworkPolicyReconcile()
+	})
+})
+
+func testSchedulerNetworkPolicies() {
+	ctx := context.Background()
+	g.By("Creating Kubernetes clients")
+	kubeConfig, err := test.NewClientConfigForTest()
+	o.Expect(err).NotTo(o.HaveOccurred())
+	kubeClient, err := kubernetes.NewForConfig(kubeConfig)
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	g.By("Waiting for kube scheduler operator to be ready")
+	err = test.WaitForOperator(ctx, kubeClient)
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	g.By("Validating NetworkPolicies in openshift-kube-scheduler")
+	schedulerDefaultDeny := getNetworkPolicy(ctx, kubeClient, schedulerNamespace, defaultDenyAllPolicyName)
+	logNetworkPolicySummary("scheduler/default-deny-all", schedulerDefaultDeny)
+	logNetworkPolicyDetails("scheduler/default-deny-all", schedulerDefaultDeny)
+	requireDefaultDenyAll(schedulerDefaultDeny)
+
+	schedulerPolicy := getNetworkPolicy(ctx, kubeClient, schedulerNamespace, schedulerPolicyName)
+	logNetworkPolicySummary("scheduler/installer-pruner", schedulerPolicy)
+	logNetworkPolicyDetails("scheduler/installer-pruner", schedulerPolicy)
+	requirePodSelectorMatchExpression(schedulerPolicy, "app", []string{"installer", "pruner"})
+	requireEgressPort(schedulerPolicy, corev1.ProtocolTCP, 5353)
+	requireEgressPort(schedulerPolicy, corev1.ProtocolUDP, 5353)
+	logEgressAllowAll(schedulerPolicy)
+
+	g.By("Validating NetworkPolicies in openshift-kube-scheduler-operator")
+	schedulerOperatorDefaultDeny := getNetworkPolicy(ctx, kubeClient, schedulerOperatorNamespace, defaultDenyAllPolicyName)
+	logNetworkPolicySummary("schedulerOperator/default-deny-all", schedulerOperatorDefaultDeny)
+	logNetworkPolicyDetails("schedulerOperator/default-deny-all", schedulerOperatorDefaultDeny)
+	requireDefaultDenyAll(schedulerOperatorDefaultDeny)
+
+	schedulerOperatorPolicy := getNetworkPolicy(ctx, kubeClient, schedulerOperatorNamespace, schedulerOperatorPolicyName)
+	logNetworkPolicySummary("schedulerOperator/kube-scheduler-operator", schedulerOperatorPolicy)
+	logNetworkPolicyDetails("schedulerOperator/kube-scheduler-operator", schedulerOperatorPolicy)
+	requirePodSelectorLabel(schedulerOperatorPolicy, "app", "openshift-kube-scheduler-operator")
+	requireIngressPort(schedulerOperatorPolicy, corev1.ProtocolTCP, 8443)
+	requireEgressPort(schedulerOperatorPolicy, corev1.ProtocolTCP, 5353)
+	requireEgressPort(schedulerOperatorPolicy, corev1.ProtocolUDP, 5353)
+	logEgressAllowAll(schedulerOperatorPolicy)
+
+	g.By("Verifying pods are ready in kube scheduler namespaces")
+	waitForPodsReadyByLabel(ctx, kubeClient, schedulerNamespace, "app=openshift-kube-scheduler")
+	waitForPodsReadyByLabel(ctx, kubeClient, schedulerNamespace, "app=guard")
+	waitForPodsReadyByLabel(ctx, kubeClient, schedulerOperatorNamespace, "app=openshift-kube-scheduler-operator")
+}
+
+func testSchedulerNetworkPolicyReconcile() {
+	ctx := context.Background()
+	g.By("Creating Kubernetes clients")
+	kubeConfig, err := test.NewClientConfigForTest()
+	o.Expect(err).NotTo(o.HaveOccurred())
+	kubeClient, err := kubernetes.NewForConfig(kubeConfig)
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	g.By("Waiting for kube scheduler operator to be ready")
+	err = test.WaitForOperator(ctx, kubeClient)
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	g.By("Capturing expected NetworkPolicy specs")
+	expectedSchedulerPolicy := getNetworkPolicy(ctx, kubeClient, schedulerNamespace, schedulerPolicyName)
+	expectedSchedulerOperatorPolicy := getNetworkPolicy(ctx, kubeClient, schedulerOperatorNamespace, schedulerOperatorPolicyName)
+	expectedSchedulerOperatorDefaultDeny := getNetworkPolicy(ctx, kubeClient, schedulerOperatorNamespace, defaultDenyAllPolicyName)
+
+	g.By("Deleting main policies and waiting for restoration")
+	restoreNetworkPolicy(ctx, kubeClient, expectedSchedulerPolicy)
+	restoreNetworkPolicy(ctx, kubeClient, expectedSchedulerOperatorPolicy)
+
+	g.By("Deleting default-deny-all policy in operator namespace and waiting for restoration")
+	restoreNetworkPolicy(ctx, kubeClient, expectedSchedulerOperatorDefaultDeny)
+
+	g.By("Mutating main policies and waiting for reconciliation")
+	mutateAndRestoreNetworkPolicy(ctx, kubeClient, schedulerNamespace, schedulerPolicyName)
+	mutateAndRestoreNetworkPolicy(ctx, kubeClient, schedulerOperatorNamespace, schedulerOperatorPolicyName)
+
+	g.By("Mutating default-deny-all policy in operator namespace and waiting for reconciliation")
+	mutateAndRestoreNetworkPolicy(ctx, kubeClient, schedulerOperatorNamespace, defaultDenyAllPolicyName)
+
+	g.By("Checking NetworkPolicy-related events (best-effort)")
+	logNetworkPolicyEvents(ctx, kubeClient, []string{"openshift-kube-scheduler-operator", schedulerNamespace}, schedulerPolicyName)
+}
+
+func getNetworkPolicy(ctx context.Context, client kubernetes.Interface, namespace, name string) *networkingv1.NetworkPolicy {
+	g.GinkgoHelper()
+	policy, err := client.NetworkingV1().NetworkPolicies(namespace).Get(ctx, name, metav1.GetOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred(), "failed to get NetworkPolicy %s/%s", namespace, name)
+	return policy
+}
+
+func requireDefaultDenyAll(policy *networkingv1.NetworkPolicy) {
+	g.GinkgoHelper()
+	if len(policy.Spec.PodSelector.MatchLabels) != 0 || len(policy.Spec.PodSelector.MatchExpressions) != 0 {
+		g.Fail(fmt.Sprintf("%s/%s: expected empty podSelector", policy.Namespace, policy.Name))
+	}
+	if len(policy.Spec.Ingress) != 0 || len(policy.Spec.Egress) != 0 {
+		g.Fail(fmt.Sprintf("%s/%s: expected no ingress or egress rules, got ingress=%d egress=%d", policy.Namespace, policy.Name, len(policy.Spec.Ingress), len(policy.Spec.Egress)))
+	}
+
+	policyTypes := sets.NewString()
+	for _, policyType := range policy.Spec.PolicyTypes {
+		policyTypes.Insert(string(policyType))
+	}
+	if !policyTypes.Has(string(networkingv1.PolicyTypeIngress)) || !policyTypes.Has(string(networkingv1.PolicyTypeEgress)) {
+		g.Fail(fmt.Sprintf("%s/%s: expected both Ingress and Egress policyTypes, got %v", policy.Namespace, policy.Name, policy.Spec.PolicyTypes))
+	}
+}
+
+func requirePodSelectorLabel(policy *networkingv1.NetworkPolicy, key, value string) {
+	g.GinkgoHelper()
+	actual, ok := policy.Spec.PodSelector.MatchLabels[key]
+	if !ok || actual != value {
+		g.Fail(fmt.Sprintf("%s/%s: expected podSelector %s=%s, got %v", policy.Namespace, policy.Name, key, value, policy.Spec.PodSelector.MatchLabels))
+	}
+}
+
+func requirePodSelectorMatchExpression(policy *networkingv1.NetworkPolicy, key string, values []string) {
+	g.GinkgoHelper()
+	found := false
+	for _, expr := range policy.Spec.PodSelector.MatchExpressions {
+		if expr.Key == key && expr.Operator == metav1.LabelSelectorOpIn {
+			if sets.NewString(expr.Values...).Equal(sets.NewString(values...)) {
+				found = true
+				break
+			}
+		}
+	}
+	if !found {
+		g.Fail(fmt.Sprintf("%s/%s: expected podSelector matchExpression %s In %v, got %v", policy.Namespace, policy.Name, key, values, policy.Spec.PodSelector.MatchExpressions))
+	}
+}
+
+func requireIngressPort(policy *networkingv1.NetworkPolicy, protocol corev1.Protocol, port int32) {
+	g.GinkgoHelper()
+	if !hasPortInIngress(policy.Spec.Ingress, protocol, port) {
+		g.Fail(fmt.Sprintf("%s/%s: expected ingress port %s/%d", policy.Namespace, policy.Name, protocol, port))
+	}
+}
+
+func requireEgressPort(policy *networkingv1.NetworkPolicy, protocol corev1.Protocol, port int32) {
+	g.GinkgoHelper()
+	if !hasPortInEgress(policy.Spec.Egress, protocol, port) {
+		g.Fail(fmt.Sprintf("%s/%s: expected egress port %s/%d", policy.Namespace, policy.Name, protocol, port))
+	}
+}
+
+func hasPortInIngress(rules []networkingv1.NetworkPolicyIngressRule, protocol corev1.Protocol, port int32) bool {
+	for _, rule := range rules {
+		if hasPort(rule.Ports, protocol, port) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasPortInEgress(rules []networkingv1.NetworkPolicyEgressRule, protocol corev1.Protocol, port int32) bool {
+	for _, rule := range rules {
+		if hasPort(rule.Ports, protocol, port) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasPort(ports []networkingv1.NetworkPolicyPort, protocol corev1.Protocol, port int32) bool {
+	for _, p := range ports {
+		if p.Port == nil || p.Port.IntValue() != int(port) {
+			continue
+		}
+		actualProtocol := corev1.ProtocolTCP
+		if p.Protocol != nil {
+			actualProtocol = *p.Protocol
+		}
+		if actualProtocol == protocol {
+			return true
+		}
+	}
+	return false
+}
+
+func hasIngressFromNamespace(rules []networkingv1.NetworkPolicyIngressRule, port int32, namespace string) bool {
+	for _, rule := range rules {
+		if !hasPort(rule.Ports, corev1.ProtocolTCP, port) {
+			continue
+		}
+		for _, peer := range rule.From {
+			if namespaceSelectorMatches(peer.NamespaceSelector, namespace) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func hasIngressAllowAll(rules []networkingv1.NetworkPolicyIngressRule, port int32) bool {
+	for _, rule := range rules {
+		if !hasPort(rule.Ports, corev1.ProtocolTCP, port) {
+			continue
+		}
+		if len(rule.From) == 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func namespaceSelectorMatches(selector *metav1.LabelSelector, namespace string) bool {
+	if selector == nil {
+		return false
+	}
+	if selector.MatchLabels != nil {
+		if selector.MatchLabels["kubernetes.io/metadata.name"] == namespace {
+			return true
+		}
+	}
+	for _, expr := range selector.MatchExpressions {
+		if expr.Key != "kubernetes.io/metadata.name" {
+			continue
+		}
+		if expr.Operator != metav1.LabelSelectorOpIn {
+			continue
+		}
+		for _, value := range expr.Values {
+			if value == namespace {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func hasIngressFromPolicyGroup(rules []networkingv1.NetworkPolicyIngressRule, port int32, policyGroupLabelKey string) bool {
+	for _, rule := range rules {
+		if !hasPort(rule.Ports, corev1.ProtocolTCP, port) {
+			continue
+		}
+		for _, peer := range rule.From {
+			if peer.NamespaceSelector == nil || peer.NamespaceSelector.MatchLabels == nil {
+				continue
+			}
+			if _, ok := peer.NamespaceSelector.MatchLabels[policyGroupLabelKey]; ok {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func logEgressAllowAll(policy *networkingv1.NetworkPolicy) {
+	g.GinkgoHelper()
+	if hasEgressAllowAll(policy.Spec.Egress) {
+		g.GinkgoWriter.Printf("networkpolicy %s/%s: egress allow-all rule present\n", policy.Namespace, policy.Name)
+		return
+	}
+	g.GinkgoWriter.Printf("networkpolicy %s/%s: no egress allow-all rule\n", policy.Namespace, policy.Name)
+}
+
+func hasEgressAllowAllTCP(rules []networkingv1.NetworkPolicyEgressRule) bool {
+	for _, rule := range rules {
+		if len(rule.To) != 0 {
+			continue
+		}
+		if hasAnyTCPPort(rule.Ports) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasAnyTCPPort(ports []networkingv1.NetworkPolicyPort) bool {
+	if len(ports) == 0 {
+		return true
+	}
+	for _, p := range ports {
+		if p.Protocol != nil && *p.Protocol != corev1.ProtocolTCP {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+func restoreNetworkPolicy(ctx context.Context, client kubernetes.Interface, expected *networkingv1.NetworkPolicy) {
+	g.GinkgoHelper()
+	namespace := expected.Namespace
+	name := expected.Name
+	g.GinkgoWriter.Printf("deleting NetworkPolicy %s/%s\n", namespace, name)
+	o.Expect(client.NetworkingV1().NetworkPolicies(namespace).Delete(ctx, name, metav1.DeleteOptions{})).NotTo(o.HaveOccurred())
+	err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 15*time.Minute, true, func(ctx context.Context) (bool, error) {
+		current, err := client.NetworkingV1().NetworkPolicies(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return false, nil
+			}
+			return false, err
+		}
+		return current.UID != expected.UID && equality.Semantic.DeepEqual(expected.Spec, current.Spec), nil
+	})
+	o.Expect(err).NotTo(o.HaveOccurred(), "timed out waiting for NetworkPolicy %s/%s spec to be restored", namespace, name)
+	g.GinkgoWriter.Printf("NetworkPolicy %s/%s spec restored after delete\n", namespace, name)
+}
+
+func mutateAndRestoreNetworkPolicy(ctx context.Context, client kubernetes.Interface, namespace, name string) {
+	g.GinkgoHelper()
+	original := getNetworkPolicy(ctx, client, namespace, name)
+	g.GinkgoWriter.Printf("mutating NetworkPolicy %s/%s (podSelector override)\n", namespace, name)
+	patch := []byte(`{"spec":{"podSelector":{"matchLabels":{"np-reconcile":"mutated"}}}}`)
+	_, err := client.NetworkingV1().NetworkPolicies(namespace).Patch(ctx, name, types.MergePatchType, patch, metav1.PatchOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 15*time.Minute, true, func(ctx context.Context) (bool, error) {
+		current := getNetworkPolicy(ctx, client, namespace, name)
+		return equality.Semantic.DeepEqual(original.Spec, current.Spec), nil
+	})
+	o.Expect(err).NotTo(o.HaveOccurred(), "timed out waiting for NetworkPolicy %s/%s spec to be restored", namespace, name)
+	g.GinkgoWriter.Printf("NetworkPolicy %s/%s spec restored\n", namespace, name)
+}
+
+func waitForPodsReadyByLabel(ctx context.Context, client kubernetes.Interface, namespace, labelSelector string) {
+	g.GinkgoHelper()
+	g.GinkgoWriter.Printf("waiting for pods ready in %s with selector %s\n", namespace, labelSelector)
+	err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
+		pods, err := client.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
+		if err != nil {
+			return false, err
+		}
+		if len(pods.Items) == 0 {
+			return false, nil
+		}
+		for _, pod := range pods.Items {
+			if !isPodReady(&pod) {
+				return false, nil
+			}
+		}
+		return true, nil
+	})
+	o.Expect(err).NotTo(o.HaveOccurred(), "timed out waiting for pods in %s with selector %s to be ready", namespace, labelSelector)
+}
+
+func isPodReady(pod *corev1.Pod) bool {
+	for _, condition := range pod.Status.Conditions {
+		if condition.Type == corev1.PodReady && condition.Status == corev1.ConditionTrue {
+			return true
+		}
+	}
+	return false
+}
+
+func logNetworkPolicyEvents(ctx context.Context, client kubernetes.Interface, namespaces []string, policyName string) {
+	g.GinkgoHelper()
+	found := false
+	_ = wait.PollUntilContextTimeout(ctx, 5*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
+		for _, namespace := range namespaces {
+			events, err := client.CoreV1().Events(namespace).List(ctx, metav1.ListOptions{})
+			if err != nil {
+				g.GinkgoWriter.Printf("unable to list events in %s: %v\n", namespace, err)
+				continue
+			}
+			for _, event := range events.Items {
+				if event.InvolvedObject.Kind == "NetworkPolicy" && event.InvolvedObject.Name == policyName {
+					g.GinkgoWriter.Printf("event in %s: %s %s %s\n", namespace, event.Type, event.Reason, event.Message)
+					found = true
+				}
+				if event.Message != "" && (event.InvolvedObject.Name == policyName || event.InvolvedObject.Kind == "NetworkPolicy") {
+					g.GinkgoWriter.Printf("event in %s: %s %s %s\n", namespace, event.Type, event.Reason, event.Message)
+					found = true
+				}
+			}
+		}
+		if found {
+			return true, nil
+		}
+		g.GinkgoWriter.Printf("no NetworkPolicy events yet for %s (namespaces: %v)\n", policyName, namespaces)
+		return false, nil
+	})
+	if !found {
+		g.GinkgoWriter.Printf("no NetworkPolicy events observed for %s (best-effort)\n", policyName)
+	}
+}
+
+func logNetworkPolicySummary(label string, policy *networkingv1.NetworkPolicy) {
+	g.GinkgoWriter.Printf("networkpolicy %s namespace=%s name=%s podSelector=%v policyTypes=%v ingress=%d egress=%d\n",
+		label,
+		policy.Namespace,
+		policy.Name,
+		policy.Spec.PodSelector.MatchLabels,
+		policy.Spec.PolicyTypes,
+		len(policy.Spec.Ingress),
+		len(policy.Spec.Egress),
+	)
+}
+
+func logNetworkPolicyDetails(label string, policy *networkingv1.NetworkPolicy) {
+	g.GinkgoHelper()
+	g.GinkgoWriter.Printf("networkpolicy %s details:\n", label)
+	g.GinkgoWriter.Printf("  podSelector=%v policyTypes=%v\n", policy.Spec.PodSelector.MatchLabels, policy.Spec.PolicyTypes)
+	for i, rule := range policy.Spec.Ingress {
+		g.GinkgoWriter.Printf("  ingress[%d]: ports=%s from=%s\n", i, formatPorts(rule.Ports), formatPeers(rule.From))
+	}
+	for i, rule := range policy.Spec.Egress {
+		g.GinkgoWriter.Printf("  egress[%d]: ports=%s to=%s\n", i, formatPorts(rule.Ports), formatPeers(rule.To))
+	}
+}
+
+func formatPorts(ports []networkingv1.NetworkPolicyPort) string {
+	if len(ports) == 0 {
+		return "[]"
+	}
+	out := make([]string, 0, len(ports))
+	for _, p := range ports {
+		proto := "TCP"
+		if p.Protocol != nil {
+			proto = string(*p.Protocol)
+		}
+		if p.Port == nil {
+			out = append(out, fmt.Sprintf("%s:any", proto))
+			continue
+		}
+		out = append(out, fmt.Sprintf("%s:%s", proto, p.Port.String()))
+	}
+	return fmt.Sprintf("[%s]", strings.Join(out, ", "))
+}
+
+func formatPeers(peers []networkingv1.NetworkPolicyPeer) string {
+	if len(peers) == 0 {
+		return "[]"
+	}
+	out := make([]string, 0, len(peers))
+	for _, peer := range peers {
+		ns := formatSelector(peer.NamespaceSelector)
+		pod := formatSelector(peer.PodSelector)
+		if ns == "" && pod == "" {
+			out = append(out, "{}")
+			continue
+		}
+		out = append(out, fmt.Sprintf("ns=%s pod=%s", ns, pod))
+	}
+	return fmt.Sprintf("[%s]", strings.Join(out, ", "))
+}
+
+func formatSelector(sel *metav1.LabelSelector) string {
+	if sel == nil {
+		return ""
+	}
+	if len(sel.MatchLabels) == 0 && len(sel.MatchExpressions) == 0 {
+		return "{}"
+	}
+	return fmt.Sprintf("labels=%v exprs=%v", sel.MatchLabels, sel.MatchExpressions)
+}
+
+func hasEgressAllowAll(rules []networkingv1.NetworkPolicyEgressRule) bool {
+	for _, rule := range rules {
+		if len(rule.To) == 0 && len(rule.Ports) == 0 {
+			return true
+		}
+	}
+	return false
+}

--- a/test/e2e/network_policy_enforcement.go
+++ b/test/e2e/network_policy_enforcement.go
@@ -1,0 +1,413 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strings"
+	"time"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+
+	test "github.com/openshift/cluster-kube-scheduler-operator/test/library"
+)
+
+const (
+	agnhostImage = "registry.k8s.io/e2e-test-images/agnhost:2.45"
+)
+
+var _ = g.Describe("[sig-scheduling] kube scheduler operator", func() {
+	g.It("[NetworkPolicy][Disruptive][Serial] should enforce generic NetworkPolicies", func() {
+		testGenericNetworkPolicyEnforcement()
+	})
+	g.It("[NetworkPolicy][Disruptive][Serial] should enforce kube scheduler NetworkPolicies", func() {
+		testSchedulerNetworkPolicyEnforcement()
+	})
+})
+
+func testGenericNetworkPolicyEnforcement() {
+	kubeConfig, err := test.NewClientConfigForTest()
+	o.Expect(err).NotTo(o.HaveOccurred())
+	kubeClient, err := kubernetes.NewForConfig(kubeConfig)
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	g.By("Creating a temporary namespace for policy enforcement checks")
+	nsName := "np-enforcement-" + rand.String(5)
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: nsName}}
+	_, err = kubeClient.CoreV1().Namespaces().Create(context.TODO(), ns, metav1.CreateOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred())
+	defer func() {
+		g.GinkgoWriter.Printf("deleting test namespace %s\n", nsName)
+		_ = kubeClient.CoreV1().Namespaces().Delete(context.TODO(), nsName, metav1.DeleteOptions{})
+	}()
+
+	serverName := "np-server"
+	clientLabels := map[string]string{"app": "np-client"}
+	serverLabels := map[string]string{"app": "np-server"}
+
+	g.GinkgoWriter.Printf("creating netexec server pod %s/%s\n", nsName, serverName)
+	serverPod := netexecPod(serverName, nsName, serverLabels, 8080)
+	_, err = kubeClient.CoreV1().Pods(nsName).Create(context.TODO(), serverPod, metav1.CreateOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred())
+	o.Expect(waitForPodReady(kubeClient, nsName, serverName)).NotTo(o.HaveOccurred())
+
+	server, err := kubeClient.CoreV1().Pods(nsName).Get(context.TODO(), serverName, metav1.GetOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred())
+	o.Expect(server.Status.PodIPs).NotTo(o.BeEmpty())
+	serverIPs := podIPs(server)
+	g.GinkgoWriter.Printf("server pod %s/%s ips=%v\n", nsName, serverName, serverIPs)
+
+	g.By("Verifying allow-all when no policies select the pod")
+	expectConnectivity(kubeClient, nsName, clientLabels, serverIPs, 8080, true)
+
+	g.By("Applying default deny and verifying traffic is blocked")
+	g.GinkgoWriter.Printf("creating default-deny policy in %s\n", nsName)
+	_, err = kubeClient.NetworkingV1().NetworkPolicies(nsName).Create(context.TODO(), defaultDenyPolicy("default-deny", nsName), metav1.CreateOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	g.By("Adding ingress allow only and verifying traffic is still blocked")
+	g.GinkgoWriter.Printf("creating allow-ingress policy in %s\n", nsName)
+	_, err = kubeClient.NetworkingV1().NetworkPolicies(nsName).Create(context.TODO(), allowIngressPolicy("allow-ingress", nsName, serverLabels, clientLabels, 8080), metav1.CreateOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred())
+	expectConnectivity(kubeClient, nsName, clientLabels, serverIPs, 8080, false)
+
+	g.By("Adding egress allow and verifying traffic is permitted")
+	g.GinkgoWriter.Printf("creating allow-egress policy in %s\n", nsName)
+	_, err = kubeClient.NetworkingV1().NetworkPolicies(nsName).Create(context.TODO(), allowEgressPolicy("allow-egress", nsName, clientLabels, serverLabels, 8080), metav1.CreateOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred())
+	expectConnectivity(kubeClient, nsName, clientLabels, serverIPs, 8080, true)
+}
+
+func testSchedulerNetworkPolicyEnforcement() {
+	kubeConfig, err := test.NewClientConfigForTest()
+	o.Expect(err).NotTo(o.HaveOccurred())
+	kubeClient, err := kubernetes.NewForConfig(kubeConfig)
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	schedulerOperatorLabels := map[string]string{"app": "openshift-kube-scheduler-operator"}
+
+	g.By("Verifying kube-scheduler-operator NetworkPolicy exists")
+	_, err = kubeClient.NetworkingV1().NetworkPolicies(schedulerOperatorNamespace).Get(context.TODO(), "kube-scheduler-operator", metav1.GetOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	g.By("Creating test pods in openshift-kube-scheduler-operator for allow/deny checks")
+	g.GinkgoWriter.Printf("creating scheduler operator server pods in %s\n", schedulerOperatorNamespace)
+	allowedServerIPs, cleanupAllowed := createServerPod(kubeClient, schedulerOperatorNamespace, "np-scheduler-op-allowed", schedulerOperatorLabels, 8443)
+	defer cleanupAllowed()
+	deniedServerIPs, cleanupDenied := createServerPod(kubeClient, schedulerOperatorNamespace, "np-scheduler-op-denied", schedulerOperatorLabels, 12345)
+	defer cleanupDenied()
+
+	g.By("Verifying allowed port 8443 ingress to scheduler operator")
+	expectConnectivity(kubeClient, schedulerOperatorNamespace, schedulerOperatorLabels, allowedServerIPs, 8443, true)
+
+	g.By("Verifying denied port 12345 (not in NetworkPolicy)")
+	expectConnectivity(kubeClient, schedulerOperatorNamespace, schedulerOperatorLabels, deniedServerIPs, 12345, false)
+
+	g.By("Verifying denied ports even from same namespace")
+	for _, port := range []int32{80, 443, 6443, 9090} {
+		expectConnectivity(kubeClient, schedulerOperatorNamespace, schedulerOperatorLabels, allowedServerIPs, port, false)
+	}
+
+	g.By("Verifying scheduler operator egress to DNS")
+	dnsSvc, err := kubeClient.CoreV1().Services("openshift-dns").Get(context.TODO(), "dns-default", metav1.GetOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred())
+	dnsIPs := serviceClusterIPs(dnsSvc)
+	g.GinkgoWriter.Printf("expecting allow from %s to DNS %v:53\n", schedulerOperatorNamespace, dnsIPs)
+	expectConnectivity(kubeClient, schedulerOperatorNamespace, schedulerOperatorLabels, dnsIPs, 53, true)
+
+	g.By("Verifying scheduler pods egress (installer/pruner policy)")
+	installerLabels := map[string]string{"app": "installer"}
+	expectConnectivity(kubeClient, schedulerNamespace, installerLabels, dnsIPs, 53, true)
+}
+
+func netexecPod(name, namespace string, labels map[string]string, port int32) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    labels,
+		},
+		Spec: corev1.PodSpec{
+			SecurityContext: &corev1.PodSecurityContext{
+				RunAsNonRoot:   boolptr(true),
+				RunAsUser:      int64ptr(1001),
+				SeccompProfile: &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
+			},
+			Containers: []corev1.Container{
+				{
+					Name:  "netexec",
+					Image: agnhostImage,
+					SecurityContext: &corev1.SecurityContext{
+						AllowPrivilegeEscalation: boolptr(false),
+						Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+						RunAsNonRoot:             boolptr(true),
+						RunAsUser:                int64ptr(1001),
+					},
+					Command: []string{"/agnhost"},
+					Args:    []string{"netexec", fmt.Sprintf("--http-port=%d", port)},
+					Ports: []corev1.ContainerPort{
+						{ContainerPort: port},
+					},
+				},
+			},
+		},
+	}
+}
+
+func createServerPod(kubeClient kubernetes.Interface, namespace, name string, labels map[string]string, port int32) ([]string, func()) {
+	g.GinkgoHelper()
+
+	g.GinkgoWriter.Printf("creating server pod %s/%s port=%d labels=%v\n", namespace, name, port, labels)
+	pod := netexecPod(name, namespace, labels, port)
+	_, err := kubeClient.CoreV1().Pods(namespace).Create(context.TODO(), pod, metav1.CreateOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred())
+	o.Expect(waitForPodReady(kubeClient, namespace, name)).NotTo(o.HaveOccurred())
+
+	created, err := kubeClient.CoreV1().Pods(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred())
+	o.Expect(created.Status.PodIPs).NotTo(o.BeEmpty())
+
+	ips := podIPs(created)
+	g.GinkgoWriter.Printf("server pod %s/%s ips=%v\n", namespace, name, ips)
+
+	return ips, func() {
+		g.GinkgoWriter.Printf("deleting server pod %s/%s\n", namespace, name)
+		_ = kubeClient.CoreV1().Pods(namespace).Delete(context.TODO(), name, metav1.DeleteOptions{})
+	}
+}
+
+// podIPs returns all IP addresses assigned to a pod (dual-stack aware).
+func podIPs(pod *corev1.Pod) []string {
+	var ips []string
+	for _, podIP := range pod.Status.PodIPs {
+		if podIP.IP != "" {
+			ips = append(ips, podIP.IP)
+		}
+	}
+	if len(ips) == 0 && pod.Status.PodIP != "" {
+		ips = append(ips, pod.Status.PodIP)
+	}
+	return ips
+}
+
+// isIPv6 returns true if the given IP string is an IPv6 address.
+func isIPv6(ip string) bool {
+	return net.ParseIP(ip) != nil && strings.Contains(ip, ":")
+}
+
+// formatIPPort formats an IP:port pair, using brackets for IPv6 addresses.
+func formatIPPort(ip string, port int32) string {
+	if isIPv6(ip) {
+		return fmt.Sprintf("[%s]:%d", ip, port)
+	}
+	return fmt.Sprintf("%s:%d", ip, port)
+}
+
+// serviceClusterIPs returns all ClusterIPs for a service (dual-stack aware).
+func serviceClusterIPs(svc *corev1.Service) []string {
+	if len(svc.Spec.ClusterIPs) > 0 {
+		return svc.Spec.ClusterIPs
+	}
+	if svc.Spec.ClusterIP != "" {
+		return []string{svc.Spec.ClusterIP}
+	}
+	return nil
+}
+
+func defaultDenyPolicy(name, namespace string) *networkingv1.NetworkPolicy {
+	return &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{},
+			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress, networkingv1.PolicyTypeEgress},
+		},
+	}
+}
+
+func allowIngressPolicy(name, namespace string, podLabels, fromLabels map[string]string, port int32) *networkingv1.NetworkPolicy {
+	return &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{MatchLabels: podLabels},
+			Ingress: []networkingv1.NetworkPolicyIngressRule{
+				{
+					From: []networkingv1.NetworkPolicyPeer{
+						{PodSelector: &metav1.LabelSelector{MatchLabels: fromLabels}},
+					},
+					Ports: []networkingv1.NetworkPolicyPort{
+						{Port: &intstr.IntOrString{Type: intstr.Int, IntVal: port}, Protocol: protocolPtr(corev1.ProtocolTCP)},
+					},
+				},
+			},
+			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+		},
+	}
+}
+
+func allowEgressPolicy(name, namespace string, podLabels, toLabels map[string]string, port int32) *networkingv1.NetworkPolicy {
+	return &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{MatchLabels: podLabels},
+			Egress: []networkingv1.NetworkPolicyEgressRule{
+				{
+					To: []networkingv1.NetworkPolicyPeer{
+						{PodSelector: &metav1.LabelSelector{MatchLabels: toLabels}},
+					},
+					Ports: []networkingv1.NetworkPolicyPort{
+						{Port: &intstr.IntOrString{Type: intstr.Int, IntVal: port}, Protocol: protocolPtr(corev1.ProtocolTCP)},
+					},
+				},
+			},
+			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeEgress},
+		},
+	}
+}
+
+// expectConnectivityForIP checks connectivity to a single IP address.
+func expectConnectivityForIP(kubeClient kubernetes.Interface, namespace string, clientLabels map[string]string, serverIP string, port int32, shouldSucceed bool) {
+	g.GinkgoHelper()
+
+	ctx := context.Background()
+	err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
+		succeeded, err := runConnectivityCheck(kubeClient, namespace, clientLabels, serverIP, port)
+		if err != nil {
+			return false, err
+		}
+		return succeeded == shouldSucceed, nil
+	})
+	o.Expect(err).NotTo(o.HaveOccurred())
+	g.GinkgoWriter.Printf("connectivity %s/%s expected=%t\n", namespace, formatIPPort(serverIP, port), shouldSucceed)
+}
+
+// expectConnectivity checks connectivity to all provided IPs (dual-stack aware).
+func expectConnectivity(kubeClient kubernetes.Interface, namespace string, clientLabels map[string]string, serverIPs []string, port int32, shouldSucceed bool) {
+	g.GinkgoHelper()
+
+	for _, ip := range serverIPs {
+		family := "IPv4"
+		if isIPv6(ip) {
+			family = "IPv6"
+		}
+		g.GinkgoWriter.Printf("checking %s connectivity %s -> %s expected=%t\n", family, namespace, formatIPPort(ip, port), shouldSucceed)
+		expectConnectivityForIP(kubeClient, namespace, clientLabels, ip, port, shouldSucceed)
+	}
+}
+
+func runConnectivityCheck(kubeClient kubernetes.Interface, namespace string, labels map[string]string, serverIP string, port int32) (bool, error) {
+	g.GinkgoHelper()
+
+	name := fmt.Sprintf("np-client-%s", rand.String(5))
+	g.GinkgoWriter.Printf("creating client pod %s/%s to connect %s:%d\n", namespace, name, serverIP, port)
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    labels,
+		},
+		Spec: corev1.PodSpec{
+			RestartPolicy: corev1.RestartPolicyNever,
+			SecurityContext: &corev1.PodSecurityContext{
+				RunAsNonRoot:   boolptr(true),
+				RunAsUser:      int64ptr(1001),
+				SeccompProfile: &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
+			},
+			Containers: []corev1.Container{
+				{
+					Name:  "connect",
+					Image: agnhostImage,
+					SecurityContext: &corev1.SecurityContext{
+						AllowPrivilegeEscalation: boolptr(false),
+						Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+						RunAsNonRoot:             boolptr(true),
+						RunAsUser:                int64ptr(1001),
+					},
+					Command: []string{"/agnhost"},
+					Args: []string{
+						"connect",
+						"--protocol=tcp",
+						"--timeout=5s",
+						formatIPPort(serverIP, port),
+					},
+				},
+			},
+		},
+	}
+
+	_, err := kubeClient.CoreV1().Pods(namespace).Create(context.TODO(), pod, metav1.CreateOptions{})
+	if err != nil {
+		return false, err
+	}
+	defer func() {
+		_ = kubeClient.CoreV1().Pods(namespace).Delete(context.TODO(), name, metav1.DeleteOptions{})
+	}()
+
+	if err := waitForPodCompletion(kubeClient, namespace, name); err != nil {
+		return false, err
+	}
+	completed, err := kubeClient.CoreV1().Pods(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		return false, err
+	}
+	if len(completed.Status.ContainerStatuses) == 0 {
+		return false, fmt.Errorf("no container status recorded for pod %s", name)
+	}
+	terminated := completed.Status.ContainerStatuses[0].State.Terminated
+	if terminated == nil {
+		return false, fmt.Errorf("container not in terminated state for pod %s", name)
+	}
+	exitCode := terminated.ExitCode
+	g.GinkgoWriter.Printf("client pod %s/%s exitCode=%d\n", namespace, name, exitCode)
+	return exitCode == 0, nil
+}
+
+func waitForPodReady(kubeClient kubernetes.Interface, namespace, name string) error {
+	ctx := context.Background()
+	return wait.PollUntilContextTimeout(ctx, 2*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
+		pod, err := kubeClient.CoreV1().Pods(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		if pod.Status.Phase != corev1.PodRunning {
+			return false, nil
+		}
+		for _, cond := range pod.Status.Conditions {
+			if cond.Type == corev1.PodReady && cond.Status == corev1.ConditionTrue {
+				return true, nil
+			}
+		}
+		return false, nil
+	})
+}
+
+func waitForPodCompletion(kubeClient kubernetes.Interface, namespace, name string) error {
+	ctx := context.Background()
+	return wait.PollUntilContextTimeout(ctx, 2*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
+		pod, err := kubeClient.CoreV1().Pods(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		return pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodFailed, nil
+	})
+}
+
+func protocolPtr(protocol corev1.Protocol) *corev1.Protocol {
+	return &protocol
+}
+
+func boolptr(value bool) *bool {
+	return &value
+}
+
+func int64ptr(value int64) *int64 {
+	return &value
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive end-to-end tests validating NetworkPolicy reconciliation in Kubernetes scheduler namespaces, including policy mutations and restoration verification.
  * Added end-to-end tests for NetworkPolicy enforcement covering connectivity rules, ingress/egress scenarios, and cross-namespace policy validation.

* **Documentation**
  * Added examples and guidance for running NetworkPolicy e2e tests using KUBECONFIG environment configuration and go test commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->