### PR TITLE
WRKLDS-1126:e2e network policy tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ $(call build-image,ocp-cluster-kube-scheduler-operator,$(IMAGE_REGISTRY)/ocp/4.2
 $(call verify-golang-versions,Dockerfile.ocp)
 
 e2e: GO_TEST_PACKAGES :=./test/e2e
+e2e: GO_TEST_FLAGS += -timeout 1h
 e2e: test-unit
 .PHONY: e2e
 

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -1,0 +1,807 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"slices"
+	"strings"
+	"time"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	agnhostImage = "registry.k8s.io/e2e-test-images/agnhost:2.45"
+)
+
+// Network Policy validation helpers
+
+func getNetworkPolicy(ctx context.Context, client kubernetes.Interface, namespace, name string) *networkingv1.NetworkPolicy {
+	g.GinkgoHelper()
+	policy, err := client.NetworkingV1().NetworkPolicies(namespace).Get(ctx, name, metav1.GetOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred(), "failed to get NetworkPolicy %s/%s", namespace, name)
+	return policy
+}
+
+func requireDefaultDenyAll(policy *networkingv1.NetworkPolicy) {
+	g.GinkgoHelper()
+	if len(policy.Spec.PodSelector.MatchLabels) != 0 || len(policy.Spec.PodSelector.MatchExpressions) != 0 {
+		g.Fail(fmt.Sprintf("%s/%s: expected empty podSelector", policy.Namespace, policy.Name))
+	}
+	if len(policy.Spec.Ingress) != 0 || len(policy.Spec.Egress) != 0 {
+		g.Fail(fmt.Sprintf("%s/%s: expected no ingress or egress rules, got ingress=%d egress=%d", policy.Namespace, policy.Name, len(policy.Spec.Ingress), len(policy.Spec.Egress)))
+	}
+
+	policyTypes := sets.NewString()
+	for _, policyType := range policy.Spec.PolicyTypes {
+		policyTypes.Insert(string(policyType))
+	}
+	if !policyTypes.Has(string(networkingv1.PolicyTypeIngress)) || !policyTypes.Has(string(networkingv1.PolicyTypeEgress)) {
+		g.Fail(fmt.Sprintf("%s/%s: expected both Ingress and Egress policyTypes, got %v", policy.Namespace, policy.Name, policy.Spec.PolicyTypes))
+	}
+}
+
+func requirePodSelectorLabel(policy *networkingv1.NetworkPolicy, key, value string) {
+	g.GinkgoHelper()
+	actual, ok := policy.Spec.PodSelector.MatchLabels[key]
+	if !ok || actual != value {
+		g.Fail(fmt.Sprintf("%s/%s: expected podSelector %s=%s, got %v", policy.Namespace, policy.Name, key, value, policy.Spec.PodSelector.MatchLabels))
+	}
+}
+
+func requirePodSelectorMatchExpression(policy *networkingv1.NetworkPolicy, key string, values []string) {
+	g.GinkgoHelper()
+	found := false
+	for _, expr := range policy.Spec.PodSelector.MatchExpressions {
+		if expr.Key == key && expr.Operator == metav1.LabelSelectorOpIn {
+			if sets.NewString(expr.Values...).Equal(sets.NewString(values...)) {
+				found = true
+				break
+			}
+		}
+	}
+	if !found {
+		g.Fail(fmt.Sprintf("%s/%s: expected podSelector matchExpression %s In %v, got %v", policy.Namespace, policy.Name, key, values, policy.Spec.PodSelector.MatchExpressions))
+	}
+}
+
+func requireIngressPort(policy *networkingv1.NetworkPolicy, protocol corev1.Protocol, port int32) {
+	g.GinkgoHelper()
+	if !hasPortInIngress(policy.Spec.Ingress, protocol, port) {
+		g.Fail(fmt.Sprintf("%s/%s: expected ingress port %s/%d", policy.Namespace, policy.Name, protocol, port))
+	}
+}
+
+func requireEgressPort(policy *networkingv1.NetworkPolicy, protocol corev1.Protocol, port int32) {
+	g.GinkgoHelper()
+	if !hasPortInEgress(policy.Spec.Egress, protocol, port) {
+		g.Fail(fmt.Sprintf("%s/%s: expected egress port %s/%d", policy.Namespace, policy.Name, protocol, port))
+	}
+}
+
+func hasPortInIngress(rules []networkingv1.NetworkPolicyIngressRule, protocol corev1.Protocol, port int32) bool {
+	for _, rule := range rules {
+		if hasPort(rule.Ports, protocol, port) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasPortInEgress(rules []networkingv1.NetworkPolicyEgressRule, protocol corev1.Protocol, port int32) bool {
+	for _, rule := range rules {
+		if hasPort(rule.Ports, protocol, port) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasPort(ports []networkingv1.NetworkPolicyPort, protocol corev1.Protocol, port int32) bool {
+	for _, p := range ports {
+		if p.Port == nil || p.Port.IntValue() != int(port) {
+			continue
+		}
+		actualProtocol := corev1.ProtocolTCP
+		if p.Protocol != nil {
+			actualProtocol = *p.Protocol
+		}
+		if actualProtocol == protocol {
+			return true
+		}
+	}
+	return false
+}
+
+func hasIngressFromNamespace(rules []networkingv1.NetworkPolicyIngressRule, port int32, namespace string) bool {
+	for _, rule := range rules {
+		if !hasPort(rule.Ports, corev1.ProtocolTCP, port) {
+			continue
+		}
+		for _, peer := range rule.From {
+			if namespaceSelectorMatches(peer.NamespaceSelector, namespace) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func hasIngressAllowAll(rules []networkingv1.NetworkPolicyIngressRule, port int32) bool {
+	for _, rule := range rules {
+		if !hasPort(rule.Ports, corev1.ProtocolTCP, port) {
+			continue
+		}
+		if len(rule.From) == 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func namespaceSelectorMatches(selector *metav1.LabelSelector, namespace string) bool {
+	if selector == nil {
+		return false
+	}
+	if selector.MatchLabels != nil {
+		if selector.MatchLabels["kubernetes.io/metadata.name"] == namespace {
+			return true
+		}
+	}
+	for _, expr := range selector.MatchExpressions {
+		if expr.Key != "kubernetes.io/metadata.name" {
+			continue
+		}
+		if expr.Operator != metav1.LabelSelectorOpIn {
+			continue
+		}
+		for _, value := range expr.Values {
+			if value == namespace {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func hasIngressFromPolicyGroup(rules []networkingv1.NetworkPolicyIngressRule, port int32, policyGroupLabelKey string) bool {
+	for _, rule := range rules {
+		if !hasPort(rule.Ports, corev1.ProtocolTCP, port) {
+			continue
+		}
+		for _, peer := range rule.From {
+			if peer.NamespaceSelector == nil || peer.NamespaceSelector.MatchLabels == nil {
+				continue
+			}
+			if _, ok := peer.NamespaceSelector.MatchLabels[policyGroupLabelKey]; ok {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func logEgressAllowAll(policy *networkingv1.NetworkPolicy) {
+	g.GinkgoHelper()
+	if hasEgressAllowAll(policy.Spec.Egress) {
+		g.GinkgoWriter.Printf("networkpolicy %s/%s: egress allow-all rule present\n", policy.Namespace, policy.Name)
+		return
+	}
+	g.GinkgoWriter.Printf("networkpolicy %s/%s: no egress allow-all rule\n", policy.Namespace, policy.Name)
+}
+
+func hasEgressAllowAllTCP(rules []networkingv1.NetworkPolicyEgressRule) bool {
+	for _, rule := range rules {
+		if len(rule.To) != 0 {
+			continue
+		}
+		if hasAnyTCPPort(rule.Ports) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasAnyTCPPort(ports []networkingv1.NetworkPolicyPort) bool {
+	if len(ports) == 0 {
+		return true
+	}
+	for _, p := range ports {
+		if p.Protocol != nil && *p.Protocol != corev1.ProtocolTCP {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+func hasEgressAllowAll(rules []networkingv1.NetworkPolicyEgressRule) bool {
+	for _, rule := range rules {
+		if len(rule.To) == 0 && len(rule.Ports) == 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func restoreNetworkPolicy(ctx context.Context, client kubernetes.Interface, expected *networkingv1.NetworkPolicy) {
+	g.GinkgoHelper()
+	namespace := expected.Namespace
+	name := expected.Name
+	g.GinkgoWriter.Printf("deleting NetworkPolicy %s/%s\n", namespace, name)
+	o.Expect(client.NetworkingV1().NetworkPolicies(namespace).Delete(ctx, name, metav1.DeleteOptions{})).NotTo(o.HaveOccurred())
+	err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 15*time.Minute, true, func(ctx context.Context) (bool, error) {
+		current, err := client.NetworkingV1().NetworkPolicies(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return false, nil
+			}
+			return false, err
+		}
+		return current.UID != expected.UID && equality.Semantic.DeepEqual(expected.Spec, current.Spec), nil
+	})
+	o.Expect(err).NotTo(o.HaveOccurred(), "timed out waiting for NetworkPolicy %s/%s spec to be restored", namespace, name)
+	g.GinkgoWriter.Printf("NetworkPolicy %s/%s spec restored after delete\n", namespace, name)
+}
+
+func mutateAndRestoreNetworkPolicy(ctx context.Context, client kubernetes.Interface, namespace, name string) {
+	g.GinkgoHelper()
+	original := getNetworkPolicy(ctx, client, namespace, name)
+	g.GinkgoWriter.Printf("mutating NetworkPolicy %s/%s (podSelector override)\n", namespace, name)
+	patch := []byte(`{"spec":{"podSelector":{"matchLabels":{"np-reconcile":"mutated"}}}}`)
+	_, err := client.NetworkingV1().NetworkPolicies(namespace).Patch(ctx, name, types.MergePatchType, patch, metav1.PatchOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 15*time.Minute, true, func(ctx context.Context) (bool, error) {
+		current := getNetworkPolicy(ctx, client, namespace, name)
+		return equality.Semantic.DeepEqual(original.Spec, current.Spec), nil
+	})
+	o.Expect(err).NotTo(o.HaveOccurred(), "timed out waiting for NetworkPolicy %s/%s spec to be restored", namespace, name)
+	g.GinkgoWriter.Printf("NetworkPolicy %s/%s spec restored\n", namespace, name)
+}
+
+func waitForPodsReadyByLabel(ctx context.Context, client kubernetes.Interface, namespace, labelSelector string) {
+	g.GinkgoHelper()
+	g.GinkgoWriter.Printf("waiting for pods ready in %s with selector %s\n", namespace, labelSelector)
+	err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
+		pods, err := client.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
+		if err != nil {
+			return false, err
+		}
+		if len(pods.Items) == 0 {
+			return false, nil
+		}
+		for _, pod := range pods.Items {
+			if !isPodReady(&pod) {
+				return false, nil
+			}
+		}
+		return true, nil
+	})
+	o.Expect(err).NotTo(o.HaveOccurred(), "timed out waiting for pods in %s with selector %s to be ready", namespace, labelSelector)
+}
+
+func isPodReady(pod *corev1.Pod) bool {
+	for _, condition := range pod.Status.Conditions {
+		if condition.Type == corev1.PodReady && condition.Status == corev1.ConditionTrue {
+			return true
+		}
+	}
+	return false
+}
+
+func logNetworkPolicyEvents(ctx context.Context, client kubernetes.Interface, namespaces []string, policyName string) {
+	g.GinkgoHelper()
+	found := false
+	_ = wait.PollUntilContextTimeout(ctx, 5*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
+		for _, namespace := range namespaces {
+			events, err := client.CoreV1().Events(namespace).List(ctx, metav1.ListOptions{})
+			if err != nil {
+				g.GinkgoWriter.Printf("unable to list events in %s: %v\n", namespace, err)
+				continue
+			}
+			for _, event := range events.Items {
+				if event.InvolvedObject.Kind == "NetworkPolicy" && event.InvolvedObject.Name == policyName {
+					g.GinkgoWriter.Printf("event in %s: %s %s %s\n", namespace, event.Type, event.Reason, event.Message)
+					found = true
+				}
+				if event.Message != "" && (event.InvolvedObject.Name == policyName || event.InvolvedObject.Kind == "NetworkPolicy") {
+					g.GinkgoWriter.Printf("event in %s: %s %s %s\n", namespace, event.Type, event.Reason, event.Message)
+					found = true
+				}
+			}
+		}
+		if found {
+			return true, nil
+		}
+		g.GinkgoWriter.Printf("no NetworkPolicy events yet for %s (namespaces: %v)\n", policyName, namespaces)
+		return false, nil
+	})
+	if !found {
+		g.GinkgoWriter.Printf("no NetworkPolicy events observed for %s (best-effort)\n", policyName)
+	}
+}
+
+func logNetworkPolicySummary(label string, policy *networkingv1.NetworkPolicy) {
+	g.GinkgoWriter.Printf("networkpolicy %s namespace=%s name=%s podSelector=%v policyTypes=%v ingress=%d egress=%d\n",
+		label,
+		policy.Namespace,
+		policy.Name,
+		policy.Spec.PodSelector.MatchLabels,
+		policy.Spec.PolicyTypes,
+		len(policy.Spec.Ingress),
+		len(policy.Spec.Egress),
+	)
+}
+
+func logNetworkPolicyDetails(label string, policy *networkingv1.NetworkPolicy) {
+	g.GinkgoHelper()
+	g.GinkgoWriter.Printf("networkpolicy %s details:\n", label)
+	g.GinkgoWriter.Printf("  podSelector=%v policyTypes=%v\n", policy.Spec.PodSelector.MatchLabels, policy.Spec.PolicyTypes)
+	for i, rule := range policy.Spec.Ingress {
+		g.GinkgoWriter.Printf("  ingress[%d]: ports=%s from=%s\n", i, formatPorts(rule.Ports), formatPeers(rule.From))
+	}
+	for i, rule := range policy.Spec.Egress {
+		g.GinkgoWriter.Printf("  egress[%d]: ports=%s to=%s\n", i, formatPorts(rule.Ports), formatPeers(rule.To))
+	}
+}
+
+func formatPorts(ports []networkingv1.NetworkPolicyPort) string {
+	if len(ports) == 0 {
+		return "[]"
+	}
+	out := make([]string, 0, len(ports))
+	for _, p := range ports {
+		proto := "TCP"
+		if p.Protocol != nil {
+			proto = string(*p.Protocol)
+		}
+		if p.Port == nil {
+			out = append(out, fmt.Sprintf("%s:any", proto))
+			continue
+		}
+		out = append(out, fmt.Sprintf("%s:%s", proto, p.Port.String()))
+	}
+	return fmt.Sprintf("[%s]", strings.Join(out, ", "))
+}
+
+func formatPeers(peers []networkingv1.NetworkPolicyPeer) string {
+	if len(peers) == 0 {
+		return "[]"
+	}
+	out := make([]string, 0, len(peers))
+	for _, peer := range peers {
+		ns := formatSelector(peer.NamespaceSelector)
+		pod := formatSelector(peer.PodSelector)
+		if ns == "" && pod == "" {
+			out = append(out, "{}")
+			continue
+		}
+		out = append(out, fmt.Sprintf("ns=%s pod=%s", ns, pod))
+	}
+	return fmt.Sprintf("[%s]", strings.Join(out, ", "))
+}
+
+func formatSelector(sel *metav1.LabelSelector) string {
+	if sel == nil {
+		return ""
+	}
+	if len(sel.MatchLabels) == 0 && len(sel.MatchExpressions) == 0 {
+		return "{}"
+	}
+	return fmt.Sprintf("labels=%v exprs=%v", sel.MatchLabels, sel.MatchExpressions)
+}
+
+// Network Policy enforcement helpers
+
+func netexecPod(name, namespace string, labels map[string]string, port int32) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    labels,
+			Annotations: map[string]string{
+				"openshift.io/required-scc": "nonroot-v2",
+			},
+		},
+		Spec: corev1.PodSpec{
+			SecurityContext: &corev1.PodSecurityContext{
+				RunAsNonRoot:   boolptr(true),
+				RunAsUser:      int64ptr(1001),
+				SeccompProfile: &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
+			},
+			Containers: []corev1.Container{
+				{
+					Name:  "netexec",
+					Image: agnhostImage,
+					SecurityContext: &corev1.SecurityContext{
+						AllowPrivilegeEscalation: boolptr(false),
+						Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+						RunAsNonRoot:             boolptr(true),
+						RunAsUser:                int64ptr(1001),
+					},
+					Command: []string{"/agnhost"},
+					Args:    []string{"netexec", fmt.Sprintf("--http-port=%d", port)},
+					Ports: []corev1.ContainerPort{
+						{ContainerPort: port},
+					},
+				},
+			},
+		},
+	}
+}
+
+func createServerPod(ctx context.Context, kubeClient kubernetes.Interface, namespace, name string, labels map[string]string, port int32) ([]string, func()) {
+	g.GinkgoHelper()
+
+	g.GinkgoWriter.Printf("creating server pod %s/%s port=%d labels=%v\n", namespace, name, port, labels)
+	pod := netexecPod(name, namespace, labels, port)
+	_, err := kubeClient.CoreV1().Pods(namespace).Create(ctx, pod, metav1.CreateOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred())
+	o.Expect(waitForPodReady(ctx, kubeClient, namespace, name)).NotTo(o.HaveOccurred())
+
+	created, err := kubeClient.CoreV1().Pods(namespace).Get(ctx, name, metav1.GetOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred())
+	o.Expect(created.Status.PodIPs).NotTo(o.BeEmpty())
+
+	ips := podIPs(created)
+	g.GinkgoWriter.Printf("server pod %s/%s ips=%v\n", namespace, name, ips)
+
+	return ips, func() {
+		g.GinkgoWriter.Printf("deleting server pod %s/%s\n", namespace, name)
+		_ = kubeClient.CoreV1().Pods(namespace).Delete(ctx, name, metav1.DeleteOptions{})
+	}
+}
+
+// podIPs returns all IP addresses assigned to a pod (dual-stack aware).
+func podIPs(pod *corev1.Pod) []string {
+	var ips []string
+	for _, podIP := range pod.Status.PodIPs {
+		if podIP.IP != "" {
+			ips = append(ips, podIP.IP)
+		}
+	}
+	if len(ips) == 0 && pod.Status.PodIP != "" {
+		ips = append(ips, pod.Status.PodIP)
+	}
+	return ips
+}
+
+// isIPv6 returns true if the given IP string is an IPv6 address.
+func isIPv6(ip string) bool {
+	return net.ParseIP(ip) != nil && strings.Contains(ip, ":")
+}
+
+// formatIPPort formats an IP:port pair, using brackets for IPv6 addresses.
+func formatIPPort(ip string, port int32) string {
+	if isIPv6(ip) {
+		return fmt.Sprintf("[%s]:%d", ip, port)
+	}
+	return fmt.Sprintf("%s:%d", ip, port)
+}
+
+// serviceClusterIPs returns all ClusterIPs for a service (dual-stack aware).
+func serviceClusterIPs(svc *corev1.Service) []string {
+	if len(svc.Spec.ClusterIPs) > 0 {
+		return svc.Spec.ClusterIPs
+	}
+	if svc.Spec.ClusterIP != "" {
+		return []string{svc.Spec.ClusterIP}
+	}
+	return nil
+}
+
+func defaultDenyPolicy(name, namespace string) *networkingv1.NetworkPolicy {
+	return &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{},
+			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress, networkingv1.PolicyTypeEgress},
+		},
+	}
+}
+
+func allowIngressPolicy(name, namespace string, podLabels, fromLabels map[string]string, port int32) *networkingv1.NetworkPolicy {
+	return &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{MatchLabels: podLabels},
+			Ingress: []networkingv1.NetworkPolicyIngressRule{
+				{
+					From: []networkingv1.NetworkPolicyPeer{
+						{PodSelector: &metav1.LabelSelector{MatchLabels: fromLabels}},
+					},
+					Ports: []networkingv1.NetworkPolicyPort{
+						{Port: &intstr.IntOrString{Type: intstr.Int, IntVal: port}, Protocol: protocolPtr(corev1.ProtocolTCP)},
+					},
+				},
+			},
+			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+		},
+	}
+}
+
+func allowEgressPolicy(name, namespace string, podLabels, toLabels map[string]string, port int32) *networkingv1.NetworkPolicy {
+	return &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{MatchLabels: podLabels},
+			Egress: []networkingv1.NetworkPolicyEgressRule{
+				{
+					To: []networkingv1.NetworkPolicyPeer{
+						{PodSelector: &metav1.LabelSelector{MatchLabels: toLabels}},
+					},
+					Ports: []networkingv1.NetworkPolicyPort{
+						{Port: &intstr.IntOrString{Type: intstr.Int, IntVal: port}, Protocol: protocolPtr(corev1.ProtocolTCP)},
+					},
+				},
+			},
+			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeEgress},
+		},
+	}
+}
+
+func expectConnectivityForIP(ctx context.Context, kubeClient kubernetes.Interface, namespace string, clientLabels map[string]string, serverIP string, port int32, shouldSucceed bool) {
+	g.GinkgoHelper()
+
+	podName, cleanup, err := createConnectivityClientPod(ctx, kubeClient, namespace, clientLabels, serverIP, port)
+	o.Expect(err).NotTo(o.HaveOccurred())
+	g.DeferCleanup(cleanup)
+
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
+		succeeded, err := readConnectivityResult(ctx, kubeClient, namespace, podName)
+		if err != nil {
+			g.GinkgoWriter.Printf("waiting for connectivity result: %v\n", err)
+			return false, nil
+		}
+		return succeeded == shouldSucceed, nil
+	})
+	o.Expect(err).NotTo(o.HaveOccurred())
+	g.GinkgoWriter.Printf("connectivity %s/%s expected=%t\n", namespace, formatIPPort(serverIP, port), shouldSucceed)
+}
+
+func expectConnectivity(ctx context.Context, kubeClient kubernetes.Interface, namespace string, clientLabels map[string]string, serverIPs []string, port int32, shouldSucceed bool) {
+	g.GinkgoHelper()
+
+	for _, ip := range serverIPs {
+		family := "IPv4"
+		if isIPv6(ip) {
+			family = "IPv6"
+		}
+		g.GinkgoWriter.Printf("checking %s connectivity %s -> %s expected=%t\n", family, namespace, formatIPPort(ip, port), shouldSucceed)
+		expectConnectivityForIP(ctx, kubeClient, namespace, clientLabels, ip, port, shouldSucceed)
+	}
+}
+
+func logConnectivityBestEffortForIP(ctx context.Context, kubeClient kubernetes.Interface, namespace string, clientLabels map[string]string, serverIP string, port int32, shouldSucceed bool) {
+	g.GinkgoHelper()
+
+	podName, cleanup, err := createConnectivityClientPod(ctx, kubeClient, namespace, clientLabels, serverIP, port)
+	if err != nil {
+		g.GinkgoWriter.Printf("failed to create client pod for best-effort check: %v\n", err)
+		return
+	}
+	g.DeferCleanup(cleanup)
+
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 30*time.Second, true, func(ctx context.Context) (bool, error) {
+		succeeded, err := readConnectivityResult(ctx, kubeClient, namespace, podName)
+		if err != nil {
+			return false, nil
+		}
+		return succeeded == shouldSucceed, nil
+	})
+	if err != nil {
+		g.GinkgoWriter.Printf("connectivity %s/%s expected=%t (best-effort) failed: %v\n", namespace, formatIPPort(serverIP, port), shouldSucceed, err)
+		return
+	}
+	g.GinkgoWriter.Printf("connectivity %s/%s expected=%t (best-effort)\n", namespace, formatIPPort(serverIP, port), shouldSucceed)
+}
+
+func logConnectivityBestEffort(ctx context.Context, kubeClient kubernetes.Interface, namespace string, clientLabels map[string]string, serverIPs []string, port int32, shouldSucceed bool) {
+	g.GinkgoHelper()
+
+	for _, ip := range serverIPs {
+		family := "IPv4"
+		if isIPv6(ip) {
+			family = "IPv6"
+		}
+		g.GinkgoWriter.Printf("checking %s connectivity (best-effort) %s -> %s expected=%t\n", family, namespace, formatIPPort(ip, port), shouldSucceed)
+		logConnectivityBestEffortForIP(ctx, kubeClient, namespace, clientLabels, ip, port, shouldSucceed)
+	}
+}
+
+// createConnectivityClientPod creates a long-running pod that continuously probes
+// TCP connectivity and writes results to stdout. Callers read the pod's logs
+// to determine the latest result, avoiding per-poll pod create/delete overhead.
+func createConnectivityClientPod(ctx context.Context, kubeClient kubernetes.Interface, namespace string, labels map[string]string, serverIP string, port int32) (string, func(), error) {
+	name := fmt.Sprintf("np-client-%s", rand.String(5))
+	target := formatIPPort(serverIP, port)
+
+	g.GinkgoWriter.Printf("creating client pod %s/%s to probe %s\n", namespace, name, target)
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    labels,
+			Annotations: map[string]string{
+				"openshift.io/required-scc": "nonroot-v2",
+			},
+		},
+		Spec: corev1.PodSpec{
+			RestartPolicy: corev1.RestartPolicyNever,
+			SecurityContext: &corev1.PodSecurityContext{
+				RunAsNonRoot:   boolptr(true),
+				RunAsUser:      int64ptr(1001),
+				SeccompProfile: &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
+			},
+			Containers: []corev1.Container{
+				{
+					Name:  "connect",
+					Image: agnhostImage,
+					SecurityContext: &corev1.SecurityContext{
+						AllowPrivilegeEscalation: boolptr(false),
+						Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+						RunAsNonRoot:             boolptr(true),
+						RunAsUser:                int64ptr(1001),
+					},
+					Command: []string{"/bin/sh", "-c"},
+					Args: []string{
+						fmt.Sprintf("while true; do if /agnhost connect --protocol=tcp --timeout=5s %s 2>/dev/null; then echo CONN_OK; else echo CONN_FAIL; fi; sleep 3; done", target),
+					},
+				},
+			},
+		},
+	}
+
+	_, err := kubeClient.CoreV1().Pods(namespace).Create(ctx, pod, metav1.CreateOptions{})
+	if err != nil {
+		return "", nil, err
+	}
+
+	if err := waitForPodReady(ctx, kubeClient, namespace, name); err != nil {
+		_ = kubeClient.CoreV1().Pods(namespace).Delete(ctx, name, metav1.DeleteOptions{})
+		return "", nil, fmt.Errorf("client pod %s/%s never became ready: %w", namespace, name, err)
+	}
+
+	cleanup := func() {
+		g.GinkgoWriter.Printf("deleting client pod %s/%s\n", namespace, name)
+		_ = kubeClient.CoreV1().Pods(namespace).Delete(ctx, name, metav1.DeleteOptions{})
+	}
+
+	return name, cleanup, nil
+}
+
+func readConnectivityResult(ctx context.Context, kubeClient kubernetes.Interface, namespace, podName string) (bool, error) {
+	tailLines := int64(1)
+	raw, err := kubeClient.CoreV1().Pods(namespace).GetLogs(podName, &corev1.PodLogOptions{
+		TailLines: &tailLines,
+	}).DoRaw(ctx)
+	if err != nil {
+		return false, err
+	}
+
+	line := strings.TrimSpace(string(raw))
+	if line == "" {
+		return false, fmt.Errorf("no connectivity result yet from pod %s/%s", namespace, podName)
+	}
+
+	g.GinkgoWriter.Printf("client pod %s/%s result=%s\n", namespace, podName, line)
+	return line == "CONN_OK", nil
+}
+
+func ingressAllowsFromNamespace(policy *networkingv1.NetworkPolicy, namespace string, labels map[string]string, port int32) bool {
+	for _, rule := range policy.Spec.Ingress {
+		if !ruleAllowsPort(rule.Ports, port) {
+			continue
+		}
+		if len(rule.From) == 0 {
+			return true
+		}
+		for _, peer := range rule.From {
+			if peer.NamespaceSelector != nil {
+				if nsMatch(peer.NamespaceSelector, namespace) && podMatch(peer.PodSelector, labels) {
+					return true
+				}
+				continue
+			}
+			if podMatch(peer.PodSelector, labels) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func nsMatch(selector *metav1.LabelSelector, namespace string) bool {
+	if selector == nil {
+		return true
+	}
+	if selector.MatchLabels != nil {
+		if selector.MatchLabels["kubernetes.io/metadata.name"] == namespace {
+			return true
+		}
+	}
+	for _, expr := range selector.MatchExpressions {
+		if expr.Key != "kubernetes.io/metadata.name" {
+			continue
+		}
+		if expr.Operator != metav1.LabelSelectorOpIn {
+			continue
+		}
+		if slices.Contains(expr.Values, namespace) {
+			return true
+		}
+	}
+	return false
+}
+
+func podMatch(selector *metav1.LabelSelector, labels map[string]string) bool {
+	if selector == nil {
+		return true
+	}
+	for key, value := range selector.MatchLabels {
+		if labels[key] != value {
+			return false
+		}
+	}
+	return true
+}
+
+func ruleAllowsPort(ports []networkingv1.NetworkPolicyPort, port int32) bool {
+	if len(ports) == 0 {
+		return true
+	}
+	for _, p := range ports {
+		if p.Port == nil {
+			return true
+		}
+		if p.Port.Type == intstr.Int && p.Port.IntVal == port {
+			return true
+		}
+	}
+	return false
+}
+
+func waitForPodReady(ctx context.Context, kubeClient kubernetes.Interface, namespace, name string) error {
+	return wait.PollUntilContextTimeout(ctx, 2*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
+		pod, err := kubeClient.CoreV1().Pods(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		if pod.Status.Phase != corev1.PodRunning {
+			return false, nil
+		}
+		for _, cond := range pod.Status.Conditions {
+			if cond.Type == corev1.PodReady && cond.Status == corev1.ConditionTrue {
+				return true, nil
+			}
+		}
+		return false, nil
+	})
+}
+
+func protocolPtr(protocol corev1.Protocol) *corev1.Protocol {
+	return &protocol
+}
+
+func boolptr(value bool) *bool {
+	return &value
+}
+
+func int64ptr(value int64) *int64 {
+	return &value
+}

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -1,0 +1,908 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"slices"
+	"strings"
+	"time"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	agnhostImage = "registry.k8s.io/e2e-test-images/agnhost:2.45"
+)
+
+// Network Policy validation helpers
+
+func getNetworkPolicy(ctx context.Context, client kubernetes.Interface, namespace, name string) *networkingv1.NetworkPolicy {
+	g.GinkgoHelper()
+	policy, err := client.NetworkingV1().NetworkPolicies(namespace).Get(ctx, name, metav1.GetOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred(), "failed to get NetworkPolicy %s/%s", namespace, name)
+	return policy
+}
+
+func requireDefaultDenyAll(policy *networkingv1.NetworkPolicy) {
+	g.GinkgoHelper()
+	if len(policy.Spec.PodSelector.MatchLabels) != 0 || len(policy.Spec.PodSelector.MatchExpressions) != 0 {
+		g.Fail(fmt.Sprintf("%s/%s: expected empty podSelector", policy.Namespace, policy.Name))
+	}
+	if len(policy.Spec.Ingress) != 0 || len(policy.Spec.Egress) != 0 {
+		g.Fail(fmt.Sprintf("%s/%s: expected no ingress or egress rules, got ingress=%d egress=%d", policy.Namespace, policy.Name, len(policy.Spec.Ingress), len(policy.Spec.Egress)))
+	}
+
+	policyTypes := sets.New[string]()
+	for _, policyType := range policy.Spec.PolicyTypes {
+		policyTypes.Insert(string(policyType))
+	}
+	if !policyTypes.Has(string(networkingv1.PolicyTypeIngress)) || !policyTypes.Has(string(networkingv1.PolicyTypeEgress)) {
+		g.Fail(fmt.Sprintf("%s/%s: expected both Ingress and Egress policyTypes, got %v", policy.Namespace, policy.Name, policy.Spec.PolicyTypes))
+	}
+}
+
+func requirePodSelectorLabel(policy *networkingv1.NetworkPolicy, key, value string) {
+	g.GinkgoHelper()
+	actual, ok := policy.Spec.PodSelector.MatchLabels[key]
+	if !ok || actual != value {
+		g.Fail(fmt.Sprintf("%s/%s: expected podSelector %s=%s, got %v", policy.Namespace, policy.Name, key, value, policy.Spec.PodSelector.MatchLabels))
+	}
+}
+
+func requirePodSelectorMatchExpression(policy *networkingv1.NetworkPolicy, key string, values []string) {
+	g.GinkgoHelper()
+	found := false
+	for _, expr := range policy.Spec.PodSelector.MatchExpressions {
+		if expr.Key == key && expr.Operator == metav1.LabelSelectorOpIn {
+			if sets.New[string](expr.Values...).Equal(sets.New[string](values...)) {
+				found = true
+				break
+			}
+		}
+	}
+	if !found {
+		g.Fail(fmt.Sprintf("%s/%s: expected podSelector matchExpression %s In %v, got %v", policy.Namespace, policy.Name, key, values, policy.Spec.PodSelector.MatchExpressions))
+	}
+}
+
+func requireIngressPort(policy *networkingv1.NetworkPolicy, protocol corev1.Protocol, port int32) {
+	g.GinkgoHelper()
+	if !hasPortInIngress(policy.Spec.Ingress, protocol, port) {
+		g.Fail(fmt.Sprintf("%s/%s: expected ingress port %s/%d", policy.Namespace, policy.Name, protocol, port))
+	}
+}
+
+func requireEgressPort(policy *networkingv1.NetworkPolicy, protocol corev1.Protocol, port int32) {
+	g.GinkgoHelper()
+	if !hasPortInEgress(policy.Spec.Egress, protocol, port) {
+		g.Fail(fmt.Sprintf("%s/%s: expected egress port %s/%d", policy.Namespace, policy.Name, protocol, port))
+	}
+}
+
+func hasPortInIngress(rules []networkingv1.NetworkPolicyIngressRule, protocol corev1.Protocol, port int32) bool {
+	for _, rule := range rules {
+		if hasPort(rule.Ports, protocol, port) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasPortInEgress(rules []networkingv1.NetworkPolicyEgressRule, protocol corev1.Protocol, port int32) bool {
+	for _, rule := range rules {
+		if hasPort(rule.Ports, protocol, port) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasPort(ports []networkingv1.NetworkPolicyPort, protocol corev1.Protocol, port int32) bool {
+	for _, p := range ports {
+		if p.Port == nil || p.Port.IntValue() != int(port) {
+			continue
+		}
+		actualProtocol := corev1.ProtocolTCP
+		if p.Protocol != nil {
+			actualProtocol = *p.Protocol
+		}
+		if actualProtocol == protocol {
+			return true
+		}
+	}
+	return false
+}
+
+func hasIngressFromNamespace(rules []networkingv1.NetworkPolicyIngressRule, port int32, namespace string) bool {
+	for _, rule := range rules {
+		if !hasPort(rule.Ports, corev1.ProtocolTCP, port) {
+			continue
+		}
+		for _, peer := range rule.From {
+			if namespaceSelectorMatches(peer.NamespaceSelector, namespace) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func hasIngressAllowAll(rules []networkingv1.NetworkPolicyIngressRule, port int32) bool {
+	for _, rule := range rules {
+		if !hasPort(rule.Ports, corev1.ProtocolTCP, port) {
+			continue
+		}
+		if len(rule.From) == 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func namespaceSelectorMatches(selector *metav1.LabelSelector, namespace string) bool {
+	if selector == nil {
+		return false
+	}
+	if selector.MatchLabels != nil {
+		if selector.MatchLabels["kubernetes.io/metadata.name"] == namespace {
+			return true
+		}
+	}
+	for _, expr := range selector.MatchExpressions {
+		if expr.Key != "kubernetes.io/metadata.name" {
+			continue
+		}
+		if expr.Operator != metav1.LabelSelectorOpIn {
+			continue
+		}
+		for _, value := range expr.Values {
+			if value == namespace {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func hasIngressFromPolicyGroup(rules []networkingv1.NetworkPolicyIngressRule, port int32, policyGroupLabelKey string) bool {
+	for _, rule := range rules {
+		if !hasPort(rule.Ports, corev1.ProtocolTCP, port) {
+			continue
+		}
+		for _, peer := range rule.From {
+			if peer.NamespaceSelector == nil || peer.NamespaceSelector.MatchLabels == nil {
+				continue
+			}
+			if _, ok := peer.NamespaceSelector.MatchLabels[policyGroupLabelKey]; ok {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func logEgressAllowAll(policy *networkingv1.NetworkPolicy) {
+	g.GinkgoHelper()
+	if hasEgressAllowAll(policy.Spec.Egress) {
+		g.GinkgoWriter.Printf("networkpolicy %s/%s: egress allow-all rule present\n", policy.Namespace, policy.Name)
+		return
+	}
+	g.GinkgoWriter.Printf("networkpolicy %s/%s: no egress allow-all rule\n", policy.Namespace, policy.Name)
+}
+
+func hasEgressAllowAllTCP(rules []networkingv1.NetworkPolicyEgressRule) bool {
+	for _, rule := range rules {
+		if len(rule.To) != 0 {
+			continue
+		}
+		if hasAnyTCPPort(rule.Ports) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasAnyTCPPort(ports []networkingv1.NetworkPolicyPort) bool {
+	if len(ports) == 0 {
+		return true
+	}
+	for _, p := range ports {
+		if p.Protocol != nil && *p.Protocol != corev1.ProtocolTCP {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+func hasEgressAllowAll(rules []networkingv1.NetworkPolicyEgressRule) bool {
+	for _, rule := range rules {
+		if len(rule.To) == 0 && len(rule.Ports) == 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// deleteAndWaitForAllRestored deletes all given NetworkPolicies at once, then
+// polls until every one is restored by the operator. This avoids the sequential
+// 15-minute-per-policy timeout that made the test slow on certain platforms.
+func deleteAndWaitForAllRestored(ctx context.Context, client kubernetes.Interface, policies []*networkingv1.NetworkPolicy) {
+	g.GinkgoHelper()
+
+	type policyState struct {
+		expected    *networkingv1.NetworkPolicy
+		originalUID types.UID
+		sawDeletion bool
+		confirmed   bool
+	}
+	states := make([]policyState, len(policies))
+
+	for i, p := range policies {
+		states[i] = policyState{expected: p, originalUID: p.UID}
+		g.GinkgoWriter.Printf("deleting NetworkPolicy %s/%s (UID=%s)\n", p.Namespace, p.Name, p.UID)
+		err := client.NetworkingV1().NetworkPolicies(p.Namespace).Delete(ctx, p.Name, metav1.DeleteOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred(), "failed to delete NetworkPolicy %s/%s", p.Namespace, p.Name)
+	}
+
+	err := wait.PollUntilContextTimeout(ctx, 15*time.Second, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
+		allRestored := true
+		for i := range states {
+			if states[i].confirmed {
+				continue
+			}
+			ns := states[i].expected.Namespace
+			name := states[i].expected.Name
+			current, err := client.NetworkingV1().NetworkPolicies(ns).Get(ctx, name, metav1.GetOptions{})
+			if apierrors.IsNotFound(err) {
+				states[i].sawDeletion = true
+				allRestored = false
+				continue
+			}
+			if err != nil {
+				allRestored = false
+				continue
+			}
+			if current.UID == states[i].originalUID && !states[i].sawDeletion {
+				allRestored = false
+				continue
+			}
+			if !equality.Semantic.DeepEqual(states[i].expected.Spec, current.Spec) {
+				allRestored = false
+				continue
+			}
+			g.GinkgoWriter.Printf("NetworkPolicy %s/%s restored\n", ns, name)
+			states[i].confirmed = true
+		}
+		return allRestored, nil
+	})
+	o.Expect(err).NotTo(o.HaveOccurred(), "timed out waiting for all NetworkPolicies to be restored after deletion")
+}
+
+// mutateAndWaitForAllReconciled mutates all given NetworkPolicies at once, then
+// polls until the operator reconciles every one back to its original spec.
+func mutateAndWaitForAllReconciled(ctx context.Context, client kubernetes.Interface, policies []struct{ namespace, name string }) {
+	g.GinkgoHelper()
+
+	type mutationState struct {
+		namespace string
+		name      string
+		original  networkingv1.NetworkPolicySpec
+		confirmed bool
+	}
+	states := make([]mutationState, 0, len(policies))
+
+	patch := []byte(`{"spec":{"podSelector":{"matchLabels":{"np-reconcile":"mutated"}}}}`)
+	for _, p := range policies {
+		original := getNetworkPolicy(ctx, client, p.namespace, p.name)
+		g.GinkgoWriter.Printf("mutating NetworkPolicy %s/%s\n", p.namespace, p.name)
+		_, err := client.NetworkingV1().NetworkPolicies(p.namespace).Patch(ctx, p.name, types.MergePatchType, patch, metav1.PatchOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred(), "failed to patch NetworkPolicy %s/%s", p.namespace, p.name)
+		states = append(states, mutationState{namespace: p.namespace, name: p.name, original: original.Spec})
+	}
+
+	// Give the operator a moment to see and process the mutations
+	time.Sleep(2 * time.Second)
+
+	err := wait.PollUntilContextTimeout(ctx, 15*time.Second, 15*time.Minute, true, func(ctx context.Context) (bool, error) {
+		allReconciled := true
+		for i := range states {
+			s := &states[i]
+			if s.confirmed {
+				continue
+			}
+			current, err := client.NetworkingV1().NetworkPolicies(s.namespace).Get(ctx, s.name, metav1.GetOptions{})
+			if err != nil {
+				g.GinkgoWriter.Printf("waiting for NetworkPolicy %s/%s reconciliation: %v\n", s.namespace, s.name, err)
+				allReconciled = false
+				continue
+			}
+			// For fast-reconciling operators, the mutation may be reverted before we can observe it.
+			// We trust that the patch succeeded and just verify the final state matches the original.
+			if !equality.Semantic.DeepEqual(s.original, current.Spec) {
+				allReconciled = false
+				continue
+			}
+			g.GinkgoWriter.Printf("NetworkPolicy %s/%s reconciled\n", s.namespace, s.name)
+			s.confirmed = true
+		}
+		return allReconciled, nil
+	})
+	o.Expect(err).NotTo(o.HaveOccurred(), "timed out waiting for all NetworkPolicies to be reconciled after mutation")
+}
+
+func waitForPodsReadyByLabel(ctx context.Context, client kubernetes.Interface, namespace, labelSelector string) {
+	g.GinkgoHelper()
+	g.GinkgoWriter.Printf("waiting for pods ready in %s with selector %s\n", namespace, labelSelector)
+	err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
+		pods, err := client.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
+		if err != nil {
+			return false, err
+		}
+		if len(pods.Items) == 0 {
+			return false, nil
+		}
+		for _, pod := range pods.Items {
+			if !isPodReady(&pod) {
+				return false, nil
+			}
+		}
+		return true, nil
+	})
+	o.Expect(err).NotTo(o.HaveOccurred(), "timed out waiting for pods in %s with selector %s to be ready", namespace, labelSelector)
+}
+
+func isPodReady(pod *corev1.Pod) bool {
+	for _, condition := range pod.Status.Conditions {
+		if condition.Type == corev1.PodReady && condition.Status == corev1.ConditionTrue {
+			return true
+		}
+	}
+	return false
+}
+
+func logNetworkPolicyEvents(ctx context.Context, client kubernetes.Interface, namespaces []string, policyName string) {
+	g.GinkgoHelper()
+	found := false
+	_ = wait.PollUntilContextTimeout(ctx, 5*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
+		for _, namespace := range namespaces {
+			events, err := client.CoreV1().Events(namespace).List(ctx, metav1.ListOptions{})
+			if err != nil {
+				g.GinkgoWriter.Printf("unable to list events in %s: %v\n", namespace, err)
+				continue
+			}
+			for _, event := range events.Items {
+				if event.InvolvedObject.Kind == "NetworkPolicy" && event.InvolvedObject.Name == policyName {
+					g.GinkgoWriter.Printf("event in %s: %s %s %s\n", namespace, event.Type, event.Reason, event.Message)
+					found = true
+				}
+				if event.Message != "" && (event.InvolvedObject.Name == policyName || event.InvolvedObject.Kind == "NetworkPolicy") {
+					g.GinkgoWriter.Printf("event in %s: %s %s %s\n", namespace, event.Type, event.Reason, event.Message)
+					found = true
+				}
+			}
+		}
+		if found {
+			return true, nil
+		}
+		g.GinkgoWriter.Printf("no NetworkPolicy events yet for %s (namespaces: %v)\n", policyName, namespaces)
+		return false, nil
+	})
+	if !found {
+		g.GinkgoWriter.Printf("no NetworkPolicy events observed for %s (best-effort)\n", policyName)
+	}
+}
+
+func logNetworkPolicySummary(label string, policy *networkingv1.NetworkPolicy) {
+	g.GinkgoWriter.Printf("networkpolicy %s namespace=%s name=%s podSelector=%v policyTypes=%v ingress=%d egress=%d\n",
+		label,
+		policy.Namespace,
+		policy.Name,
+		policy.Spec.PodSelector.MatchLabels,
+		policy.Spec.PolicyTypes,
+		len(policy.Spec.Ingress),
+		len(policy.Spec.Egress),
+	)
+}
+
+func logNetworkPolicyDetails(label string, policy *networkingv1.NetworkPolicy) {
+	g.GinkgoHelper()
+	g.GinkgoWriter.Printf("networkpolicy %s details:\n", label)
+	g.GinkgoWriter.Printf("  podSelector=%v policyTypes=%v\n", policy.Spec.PodSelector.MatchLabels, policy.Spec.PolicyTypes)
+	for i, rule := range policy.Spec.Ingress {
+		g.GinkgoWriter.Printf("  ingress[%d]: ports=%s from=%s\n", i, formatPorts(rule.Ports), formatPeers(rule.From))
+	}
+	for i, rule := range policy.Spec.Egress {
+		g.GinkgoWriter.Printf("  egress[%d]: ports=%s to=%s\n", i, formatPorts(rule.Ports), formatPeers(rule.To))
+	}
+}
+
+func formatPorts(ports []networkingv1.NetworkPolicyPort) string {
+	if len(ports) == 0 {
+		return "[]"
+	}
+	out := make([]string, 0, len(ports))
+	for _, p := range ports {
+		proto := "TCP"
+		if p.Protocol != nil {
+			proto = string(*p.Protocol)
+		}
+		if p.Port == nil {
+			out = append(out, fmt.Sprintf("%s:any", proto))
+			continue
+		}
+		out = append(out, fmt.Sprintf("%s:%s", proto, p.Port.String()))
+	}
+	return fmt.Sprintf("[%s]", strings.Join(out, ", "))
+}
+
+func formatPeers(peers []networkingv1.NetworkPolicyPeer) string {
+	if len(peers) == 0 {
+		return "[]"
+	}
+	out := make([]string, 0, len(peers))
+	for _, peer := range peers {
+		ns := formatSelector(peer.NamespaceSelector)
+		pod := formatSelector(peer.PodSelector)
+		if ns == "" && pod == "" {
+			out = append(out, "{}")
+			continue
+		}
+		out = append(out, fmt.Sprintf("ns=%s pod=%s", ns, pod))
+	}
+	return fmt.Sprintf("[%s]", strings.Join(out, ", "))
+}
+
+func formatSelector(sel *metav1.LabelSelector) string {
+	if sel == nil {
+		return ""
+	}
+	if len(sel.MatchLabels) == 0 && len(sel.MatchExpressions) == 0 {
+		return "{}"
+	}
+	return fmt.Sprintf("labels=%v exprs=%v", sel.MatchLabels, sel.MatchExpressions)
+}
+
+// Network Policy enforcement helpers
+
+func netexecPod(name, namespace string, labels map[string]string, port int32) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    labels,
+			Annotations: map[string]string{
+				"openshift.io/required-scc": "nonroot-v2",
+			},
+		},
+		Spec: corev1.PodSpec{
+			ServiceAccountName:           "network-policy-test",
+			AutomountServiceAccountToken: boolptr(false),
+			SecurityContext: &corev1.PodSecurityContext{
+				RunAsNonRoot:   boolptr(true),
+				RunAsUser:      int64ptr(1001),
+				SeccompProfile: &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
+			},
+			Containers: []corev1.Container{
+				{
+					Name:  "netexec",
+					Image: agnhostImage,
+					SecurityContext: &corev1.SecurityContext{
+						AllowPrivilegeEscalation: boolptr(false),
+						Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+						RunAsNonRoot:             boolptr(true),
+						RunAsUser:                int64ptr(1001),
+					},
+					TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+					Command:                  []string{"/agnhost"},
+					Args:                     []string{"netexec", fmt.Sprintf("--http-port=%d", port)},
+					Ports: []corev1.ContainerPort{
+						{ContainerPort: port},
+					},
+				},
+			},
+		},
+	}
+}
+
+func createServerPod(ctx context.Context, kubeClient kubernetes.Interface, namespace, name string, labels map[string]string, port int32) ([]string, func()) {
+	g.GinkgoHelper()
+
+	err := ensureTestServiceAccount(ctx, kubeClient, namespace)
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	g.GinkgoWriter.Printf("creating server pod %s/%s port=%d labels=%v\n", namespace, name, port, labels)
+	pod := netexecPod(name, namespace, labels, port)
+	_, err = kubeClient.CoreV1().Pods(namespace).Create(ctx, pod, metav1.CreateOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred())
+	o.Expect(waitForPodReady(ctx, kubeClient, namespace, name)).NotTo(o.HaveOccurred())
+
+	created, err := kubeClient.CoreV1().Pods(namespace).Get(ctx, name, metav1.GetOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred())
+	o.Expect(created.Status.PodIPs).NotTo(o.BeEmpty())
+
+	ips := podIPs(created)
+	g.GinkgoWriter.Printf("server pod %s/%s ips=%v\n", namespace, name, ips)
+
+	return ips, func() {
+		g.GinkgoWriter.Printf("deleting server pod %s/%s\n", namespace, name)
+		_ = kubeClient.CoreV1().Pods(namespace).Delete(ctx, name, metav1.DeleteOptions{})
+	}
+}
+
+// podIPs returns all IP addresses assigned to a pod (dual-stack aware).
+func podIPs(pod *corev1.Pod) []string {
+	var ips []string
+	for _, podIP := range pod.Status.PodIPs {
+		if podIP.IP != "" {
+			ips = append(ips, podIP.IP)
+		}
+	}
+	if len(ips) == 0 && pod.Status.PodIP != "" {
+		ips = append(ips, pod.Status.PodIP)
+	}
+	return ips
+}
+
+// isIPv6 returns true if the given IP string is an IPv6 address.
+func isIPv6(ip string) bool {
+	return net.ParseIP(ip) != nil && strings.Contains(ip, ":")
+}
+
+// formatIPPort formats an IP:port pair, using brackets for IPv6 addresses.
+func formatIPPort(ip string, port int32) string {
+	if isIPv6(ip) {
+		return fmt.Sprintf("[%s]:%d", ip, port)
+	}
+	return fmt.Sprintf("%s:%d", ip, port)
+}
+
+// serviceClusterIPs returns all ClusterIPs for a service (dual-stack aware).
+func serviceClusterIPs(svc *corev1.Service) []string {
+	if len(svc.Spec.ClusterIPs) > 0 {
+		return svc.Spec.ClusterIPs
+	}
+	if svc.Spec.ClusterIP != "" {
+		return []string{svc.Spec.ClusterIP}
+	}
+	return nil
+}
+
+func defaultDenyPolicy(name, namespace string) *networkingv1.NetworkPolicy {
+	return &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{},
+			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress, networkingv1.PolicyTypeEgress},
+		},
+	}
+}
+
+func allowIngressPolicy(name, namespace string, podLabels, fromLabels map[string]string, port int32) *networkingv1.NetworkPolicy {
+	return &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{MatchLabels: podLabels},
+			Ingress: []networkingv1.NetworkPolicyIngressRule{
+				{
+					From: []networkingv1.NetworkPolicyPeer{
+						{PodSelector: &metav1.LabelSelector{MatchLabels: fromLabels}},
+					},
+					Ports: []networkingv1.NetworkPolicyPort{
+						{Port: &intstr.IntOrString{Type: intstr.Int, IntVal: port}, Protocol: protocolPtr(corev1.ProtocolTCP)},
+					},
+				},
+			},
+			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+		},
+	}
+}
+
+func allowEgressPolicy(name, namespace string, podLabels, toLabels map[string]string, port int32) *networkingv1.NetworkPolicy {
+	return &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{MatchLabels: podLabels},
+			Egress: []networkingv1.NetworkPolicyEgressRule{
+				{
+					To: []networkingv1.NetworkPolicyPeer{
+						{PodSelector: &metav1.LabelSelector{MatchLabels: toLabels}},
+					},
+					Ports: []networkingv1.NetworkPolicyPort{
+						{Port: &intstr.IntOrString{Type: intstr.Int, IntVal: port}, Protocol: protocolPtr(corev1.ProtocolTCP)},
+					},
+				},
+			},
+			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeEgress},
+		},
+	}
+}
+
+func expectConnectivityForIP(ctx context.Context, kubeClient kubernetes.Interface, namespace string, clientLabels map[string]string, serverIP string, port int32, shouldSucceed bool) {
+	g.GinkgoHelper()
+
+	podName, cleanup, err := createConnectivityClientPod(ctx, kubeClient, namespace, clientLabels, serverIP, port)
+	o.Expect(err).NotTo(o.HaveOccurred())
+	g.DeferCleanup(cleanup)
+
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
+		succeeded, err := readConnectivityResult(ctx, kubeClient, namespace, podName)
+		if err != nil {
+			g.GinkgoWriter.Printf("waiting for connectivity result: %v\n", err)
+			return false, nil
+		}
+		return succeeded == shouldSucceed, nil
+	})
+	o.Expect(err).NotTo(o.HaveOccurred())
+	g.GinkgoWriter.Printf("connectivity %s/%s expected=%t\n", namespace, formatIPPort(serverIP, port), shouldSucceed)
+}
+
+func expectConnectivity(ctx context.Context, kubeClient kubernetes.Interface, namespace string, clientLabels map[string]string, serverIPs []string, port int32, shouldSucceed bool) {
+	g.GinkgoHelper()
+
+	for _, ip := range serverIPs {
+		family := "IPv4"
+		if isIPv6(ip) {
+			family = "IPv6"
+		}
+		g.GinkgoWriter.Printf("checking %s connectivity %s -> %s expected=%t\n", family, namespace, formatIPPort(ip, port), shouldSucceed)
+		expectConnectivityForIP(ctx, kubeClient, namespace, clientLabels, ip, port, shouldSucceed)
+	}
+}
+
+func logConnectivityBestEffortForIP(ctx context.Context, kubeClient kubernetes.Interface, namespace string, clientLabels map[string]string, serverIP string, port int32, shouldSucceed bool) {
+	g.GinkgoHelper()
+
+	podName, cleanup, err := createConnectivityClientPod(ctx, kubeClient, namespace, clientLabels, serverIP, port)
+	if err != nil {
+		g.GinkgoWriter.Printf("failed to create client pod for best-effort check: %v\n", err)
+		return
+	}
+	g.DeferCleanup(cleanup)
+
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 30*time.Second, true, func(ctx context.Context) (bool, error) {
+		succeeded, err := readConnectivityResult(ctx, kubeClient, namespace, podName)
+		if err != nil {
+			return false, nil
+		}
+		return succeeded == shouldSucceed, nil
+	})
+	if err != nil {
+		g.GinkgoWriter.Printf("connectivity %s/%s expected=%t (best-effort) failed: %v\n", namespace, formatIPPort(serverIP, port), shouldSucceed, err)
+		return
+	}
+	g.GinkgoWriter.Printf("connectivity %s/%s expected=%t (best-effort)\n", namespace, formatIPPort(serverIP, port), shouldSucceed)
+}
+
+func logConnectivityBestEffort(ctx context.Context, kubeClient kubernetes.Interface, namespace string, clientLabels map[string]string, serverIPs []string, port int32, shouldSucceed bool) {
+	g.GinkgoHelper()
+
+	for _, ip := range serverIPs {
+		family := "IPv4"
+		if isIPv6(ip) {
+			family = "IPv6"
+		}
+		g.GinkgoWriter.Printf("checking %s connectivity (best-effort) %s -> %s expected=%t\n", family, namespace, formatIPPort(ip, port), shouldSucceed)
+		logConnectivityBestEffortForIP(ctx, kubeClient, namespace, clientLabels, ip, port, shouldSucceed)
+	}
+}
+
+// createConnectivityClientPod creates a long-running pod that continuously probes
+// TCP connectivity and writes results to stdout. Callers read the pod's logs
+// to determine the latest result, avoiding per-poll pod create/delete overhead.
+func createConnectivityClientPod(ctx context.Context, kubeClient kubernetes.Interface, namespace string, labels map[string]string, serverIP string, port int32) (string, func(), error) {
+	name := fmt.Sprintf("np-client-%s", rand.String(5))
+	target := formatIPPort(serverIP, port)
+
+	if err := ensureTestServiceAccount(ctx, kubeClient, namespace); err != nil {
+		return "", nil, fmt.Errorf("failed to ensure service account: %w", err)
+	}
+
+	g.GinkgoWriter.Printf("creating client pod %s/%s to probe %s\n", namespace, name, target)
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    labels,
+			Annotations: map[string]string{
+				"openshift.io/required-scc": "nonroot-v2",
+			},
+		},
+		Spec: corev1.PodSpec{
+			ServiceAccountName:           "network-policy-test",
+			AutomountServiceAccountToken: boolptr(false),
+			RestartPolicy:                corev1.RestartPolicyNever,
+			SecurityContext: &corev1.PodSecurityContext{
+				RunAsNonRoot:   boolptr(true),
+				RunAsUser:      int64ptr(1001),
+				SeccompProfile: &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
+			},
+			Containers: []corev1.Container{
+				{
+					Name:  "connect",
+					Image: agnhostImage,
+					SecurityContext: &corev1.SecurityContext{
+						AllowPrivilegeEscalation: boolptr(false),
+						Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+						RunAsNonRoot:             boolptr(true),
+						RunAsUser:                int64ptr(1001),
+					},
+					TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+					Command:                  []string{"/bin/sh", "-c"},
+					Args: []string{
+						fmt.Sprintf("while true; do if /agnhost connect --protocol=tcp --timeout=5s %s 2>/dev/null; then echo CONN_OK; else echo CONN_FAIL; fi; sleep 3; done", target),
+					},
+				},
+			},
+		},
+	}
+
+	_, err := kubeClient.CoreV1().Pods(namespace).Create(ctx, pod, metav1.CreateOptions{})
+	if err != nil {
+		return "", nil, err
+	}
+
+	if err := waitForPodReady(ctx, kubeClient, namespace, name); err != nil {
+		_ = kubeClient.CoreV1().Pods(namespace).Delete(ctx, name, metav1.DeleteOptions{})
+		return "", nil, fmt.Errorf("client pod %s/%s never became ready: %w", namespace, name, err)
+	}
+
+	cleanup := func() {
+		g.GinkgoWriter.Printf("deleting client pod %s/%s\n", namespace, name)
+		_ = kubeClient.CoreV1().Pods(namespace).Delete(ctx, name, metav1.DeleteOptions{})
+	}
+
+	return name, cleanup, nil
+}
+
+func readConnectivityResult(ctx context.Context, kubeClient kubernetes.Interface, namespace, podName string) (bool, error) {
+	tailLines := int64(1)
+	raw, err := kubeClient.CoreV1().Pods(namespace).GetLogs(podName, &corev1.PodLogOptions{
+		TailLines: &tailLines,
+	}).DoRaw(ctx)
+	if err != nil {
+		return false, err
+	}
+
+	line := strings.TrimSpace(string(raw))
+	if line == "" {
+		return false, fmt.Errorf("no connectivity result yet from pod %s/%s", namespace, podName)
+	}
+
+	g.GinkgoWriter.Printf("client pod %s/%s result=%s\n", namespace, podName, line)
+	return line == "CONN_OK", nil
+}
+
+func ingressAllowsFromNamespace(policy *networkingv1.NetworkPolicy, namespace string, labels map[string]string, port int32) bool {
+	for _, rule := range policy.Spec.Ingress {
+		if !ruleAllowsPort(rule.Ports, port) {
+			continue
+		}
+		if len(rule.From) == 0 {
+			return true
+		}
+		for _, peer := range rule.From {
+			if peer.NamespaceSelector != nil {
+				if nsMatch(peer.NamespaceSelector, namespace) && podMatch(peer.PodSelector, labels) {
+					return true
+				}
+				continue
+			}
+			if podMatch(peer.PodSelector, labels) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func nsMatch(selector *metav1.LabelSelector, namespace string) bool {
+	if selector == nil {
+		return true
+	}
+	if selector.MatchLabels != nil {
+		if selector.MatchLabels["kubernetes.io/metadata.name"] == namespace {
+			return true
+		}
+	}
+	for _, expr := range selector.MatchExpressions {
+		if expr.Key != "kubernetes.io/metadata.name" {
+			continue
+		}
+		if expr.Operator != metav1.LabelSelectorOpIn {
+			continue
+		}
+		if slices.Contains(expr.Values, namespace) {
+			return true
+		}
+	}
+	return false
+}
+
+func podMatch(selector *metav1.LabelSelector, labels map[string]string) bool {
+	if selector == nil {
+		return true
+	}
+	for key, value := range selector.MatchLabels {
+		if labels[key] != value {
+			return false
+		}
+	}
+	return true
+}
+
+func ruleAllowsPort(ports []networkingv1.NetworkPolicyPort, port int32) bool {
+	if len(ports) == 0 {
+		return true
+	}
+	for _, p := range ports {
+		if p.Port == nil {
+			return true
+		}
+		if p.Port.Type == intstr.Int && p.Port.IntVal == port {
+			return true
+		}
+	}
+	return false
+}
+
+func waitForPodReady(ctx context.Context, kubeClient kubernetes.Interface, namespace, name string) error {
+	return wait.PollUntilContextTimeout(ctx, 2*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
+		pod, err := kubeClient.CoreV1().Pods(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		if pod.Status.Phase != corev1.PodRunning {
+			return false, nil
+		}
+		for _, cond := range pod.Status.Conditions {
+			if cond.Type == corev1.PodReady && cond.Status == corev1.ConditionTrue {
+				return true, nil
+			}
+		}
+		return false, nil
+	})
+}
+
+func protocolPtr(protocol corev1.Protocol) *corev1.Protocol {
+	return &protocol
+}
+
+func boolptr(value bool) *bool {
+	return &value
+}
+
+func int64ptr(value int64) *int64 {
+	return &value
+}
+
+// ensureTestServiceAccount creates a non-default service account for network policy tests
+// to avoid triggering the default service account monitor test failures.
+func ensureTestServiceAccount(ctx context.Context, kubeClient kubernetes.Interface, namespace string) error {
+	saName := "network-policy-test"
+	sa := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      saName,
+			Namespace: namespace,
+		},
+	}
+	_, err := kubeClient.CoreV1().ServiceAccounts(namespace).Create(ctx, sa, metav1.CreateOptions{})
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		return err
+	}
+	return nil
+}

--- a/test/e2e/network_policy.go
+++ b/test/e2e/network_policy.go
@@ -1,0 +1,112 @@
+package e2e
+
+import (
+	"context"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+
+	test "github.com/openshift/cluster-kube-scheduler-operator/test/library"
+)
+
+const (
+	schedulerNamespace          = "openshift-kube-scheduler"
+	schedulerOperatorNamespace  = "openshift-kube-scheduler-operator"
+	defaultDenyAllPolicyName    = "default-deny-all"
+	schedulerPolicyName         = "installer-pruner"
+	schedulerOperatorPolicyName = "kube-scheduler-operator"
+)
+
+var _ = g.Describe("[sig-scheduling] kube scheduler operator", func() {
+	g.It("[NetworkPolicy] should ensure kube scheduler NetworkPolicies are defined", func() {
+		testSchedulerNetworkPolicies()
+	})
+	g.It("[NetworkPolicy][Serial] should restore kube scheduler NetworkPolicies after delete or mutation[Timeout:30m]", func() {
+		testSchedulerNetworkPolicyReconcile()
+	})
+})
+
+func testSchedulerNetworkPolicies() {
+	ctx := context.Background()
+	g.By("Creating Kubernetes clients")
+	kubeConfig, err := test.NewClientConfigForTest()
+	o.Expect(err).NotTo(o.HaveOccurred())
+	kubeClient, err := kubernetes.NewForConfig(kubeConfig)
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	g.By("Waiting for kube scheduler operator to be ready")
+	err = test.WaitForOperator(ctx, kubeClient)
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	g.By("Validating NetworkPolicies in openshift-kube-scheduler")
+	schedulerDefaultDeny := getNetworkPolicy(ctx, kubeClient, schedulerNamespace, defaultDenyAllPolicyName)
+	logNetworkPolicySummary("scheduler/default-deny-all", schedulerDefaultDeny)
+	logNetworkPolicyDetails("scheduler/default-deny-all", schedulerDefaultDeny)
+	requireDefaultDenyAll(schedulerDefaultDeny)
+
+	schedulerPolicy := getNetworkPolicy(ctx, kubeClient, schedulerNamespace, schedulerPolicyName)
+	logNetworkPolicySummary("scheduler/installer-pruner", schedulerPolicy)
+	logNetworkPolicyDetails("scheduler/installer-pruner", schedulerPolicy)
+	requirePodSelectorMatchExpression(schedulerPolicy, "app", []string{"installer", "pruner"})
+	requireEgressPort(schedulerPolicy, corev1.ProtocolTCP, 5353)
+	requireEgressPort(schedulerPolicy, corev1.ProtocolUDP, 5353)
+	logEgressAllowAll(schedulerPolicy)
+
+	g.By("Validating NetworkPolicies in openshift-kube-scheduler-operator")
+	schedulerOperatorDefaultDeny := getNetworkPolicy(ctx, kubeClient, schedulerOperatorNamespace, defaultDenyAllPolicyName)
+	logNetworkPolicySummary("schedulerOperator/default-deny-all", schedulerOperatorDefaultDeny)
+	logNetworkPolicyDetails("schedulerOperator/default-deny-all", schedulerOperatorDefaultDeny)
+	requireDefaultDenyAll(schedulerOperatorDefaultDeny)
+
+	schedulerOperatorPolicy := getNetworkPolicy(ctx, kubeClient, schedulerOperatorNamespace, schedulerOperatorPolicyName)
+	logNetworkPolicySummary("schedulerOperator/kube-scheduler-operator", schedulerOperatorPolicy)
+	logNetworkPolicyDetails("schedulerOperator/kube-scheduler-operator", schedulerOperatorPolicy)
+	requirePodSelectorLabel(schedulerOperatorPolicy, "app", "openshift-kube-scheduler-operator")
+	requireIngressPort(schedulerOperatorPolicy, corev1.ProtocolTCP, 8443)
+	requireEgressPort(schedulerOperatorPolicy, corev1.ProtocolTCP, 5353)
+	requireEgressPort(schedulerOperatorPolicy, corev1.ProtocolUDP, 5353)
+	logEgressAllowAll(schedulerOperatorPolicy)
+
+	g.By("Verifying pods are ready in kube scheduler namespaces")
+	waitForPodsReadyByLabel(ctx, kubeClient, schedulerNamespace, "app=openshift-kube-scheduler")
+	waitForPodsReadyByLabel(ctx, kubeClient, schedulerNamespace, "app=guard")
+	waitForPodsReadyByLabel(ctx, kubeClient, schedulerOperatorNamespace, "app=openshift-kube-scheduler-operator")
+}
+
+func testSchedulerNetworkPolicyReconcile() {
+	ctx := context.Background()
+	g.By("Creating Kubernetes clients")
+	kubeConfig, err := test.NewClientConfigForTest()
+	o.Expect(err).NotTo(o.HaveOccurred())
+	kubeClient, err := kubernetes.NewForConfig(kubeConfig)
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	g.By("Waiting for kube scheduler operator to be ready")
+	err = test.WaitForOperator(ctx, kubeClient)
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	g.By("Capturing expected NetworkPolicy specs")
+	expectedSchedulerPolicy := getNetworkPolicy(ctx, kubeClient, schedulerNamespace, schedulerPolicyName)
+	expectedSchedulerOperatorPolicy := getNetworkPolicy(ctx, kubeClient, schedulerOperatorNamespace, schedulerOperatorPolicyName)
+	expectedSchedulerOperatorDefaultDeny := getNetworkPolicy(ctx, kubeClient, schedulerOperatorNamespace, defaultDenyAllPolicyName)
+
+	g.By("Deleting main policies and waiting for restoration")
+	restoreNetworkPolicy(ctx, kubeClient, expectedSchedulerPolicy)
+	restoreNetworkPolicy(ctx, kubeClient, expectedSchedulerOperatorPolicy)
+
+	g.By("Deleting default-deny-all policy in operator namespace and waiting for restoration")
+	restoreNetworkPolicy(ctx, kubeClient, expectedSchedulerOperatorDefaultDeny)
+
+	g.By("Mutating main policies and waiting for reconciliation")
+	mutateAndRestoreNetworkPolicy(ctx, kubeClient, schedulerNamespace, schedulerPolicyName)
+	mutateAndRestoreNetworkPolicy(ctx, kubeClient, schedulerOperatorNamespace, schedulerOperatorPolicyName)
+
+	g.By("Mutating default-deny-all policy in operator namespace and waiting for reconciliation")
+	mutateAndRestoreNetworkPolicy(ctx, kubeClient, schedulerOperatorNamespace, defaultDenyAllPolicyName)
+
+	g.By("Checking NetworkPolicy-related events (best-effort)")
+	logNetworkPolicyEvents(ctx, kubeClient, []string{"openshift-kube-scheduler-operator", schedulerNamespace}, schedulerPolicyName)
+}

--- a/test/e2e/network_policy.go
+++ b/test/e2e/network_policy.go
@@ -1,0 +1,124 @@
+package e2e
+
+import (
+	"context"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	"k8s.io/client-go/kubernetes"
+
+	test "github.com/openshift/cluster-kube-scheduler-operator/test/library"
+)
+
+const (
+	schedulerNamespace          = "openshift-kube-scheduler"
+	schedulerOperatorNamespace  = "openshift-kube-scheduler-operator"
+	defaultDenyAllPolicyName    = "default-deny-all"
+	schedulerPolicyName         = "installer-pruner"
+	schedulerOperatorPolicyName = "kube-scheduler-operator"
+)
+
+var _ = g.Describe("[sig-scheduling] kube scheduler operator", func() {
+	g.It("[NetworkPolicy][Operator][Parallel] should ensure kube scheduler NetworkPolicies are defined", func() {
+		testSchedulerNetworkPolicies()
+	})
+	g.It("[NetworkPolicy][Operator][Serial] should restore kube scheduler NetworkPolicies after delete or mutation", func() {
+		testSchedulerNetworkPolicyReconcile()
+	})
+})
+
+func testSchedulerNetworkPolicies() {
+	ctx := context.Background()
+	g.By("Creating Kubernetes clients")
+	kubeConfig, err := test.NewClientConfigForTest()
+	o.Expect(err).NotTo(o.HaveOccurred())
+	kubeClient, err := kubernetes.NewForConfig(kubeConfig)
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	g.By("Waiting for kube scheduler operator to be ready")
+	err = test.WaitForOperator(ctx, kubeClient)
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	g.By("Validating NetworkPolicies in openshift-kube-scheduler")
+	schedulerDefaultDeny := getNetworkPolicy(ctx, kubeClient, schedulerNamespace, defaultDenyAllPolicyName)
+	logNetworkPolicySummary("scheduler/default-deny-all", schedulerDefaultDeny)
+	logNetworkPolicyDetails("scheduler/default-deny-all", schedulerDefaultDeny)
+	requireDefaultDenyAll(schedulerDefaultDeny)
+
+	schedulerPolicy := getNetworkPolicy(ctx, kubeClient, schedulerNamespace, schedulerPolicyName)
+	logNetworkPolicySummary("scheduler/installer-pruner", schedulerPolicy)
+	logNetworkPolicyDetails("scheduler/installer-pruner", schedulerPolicy)
+	requirePodSelectorMatchExpression(schedulerPolicy, "app", []string{"installer", "pruner"})
+	requireEgressPort(schedulerPolicy, corev1.ProtocolTCP, 5353)
+	requireEgressPort(schedulerPolicy, corev1.ProtocolUDP, 5353)
+	logEgressAllowAll(schedulerPolicy)
+
+	g.By("Validating NetworkPolicies in openshift-kube-scheduler-operator")
+	schedulerOperatorDefaultDeny := getNetworkPolicy(ctx, kubeClient, schedulerOperatorNamespace, defaultDenyAllPolicyName)
+	logNetworkPolicySummary("schedulerOperator/default-deny-all", schedulerOperatorDefaultDeny)
+	logNetworkPolicyDetails("schedulerOperator/default-deny-all", schedulerOperatorDefaultDeny)
+	requireDefaultDenyAll(schedulerOperatorDefaultDeny)
+
+	schedulerOperatorPolicy := getNetworkPolicy(ctx, kubeClient, schedulerOperatorNamespace, schedulerOperatorPolicyName)
+	logNetworkPolicySummary("schedulerOperator/kube-scheduler-operator", schedulerOperatorPolicy)
+	logNetworkPolicyDetails("schedulerOperator/kube-scheduler-operator", schedulerOperatorPolicy)
+	requirePodSelectorLabel(schedulerOperatorPolicy, "app", "openshift-kube-scheduler-operator")
+	requireIngressPort(schedulerOperatorPolicy, corev1.ProtocolTCP, 8443)
+	requireEgressPort(schedulerOperatorPolicy, corev1.ProtocolTCP, 5353)
+	requireEgressPort(schedulerOperatorPolicy, corev1.ProtocolUDP, 5353)
+	logEgressAllowAll(schedulerOperatorPolicy)
+
+	g.By("Verifying pods are ready in kube scheduler namespaces")
+	waitForPodsReadyByLabel(ctx, kubeClient, schedulerNamespace, "app=openshift-kube-scheduler")
+	waitForPodsReadyByLabel(ctx, kubeClient, schedulerNamespace, "app=guard")
+	waitForPodsReadyByLabel(ctx, kubeClient, schedulerOperatorNamespace, "app=openshift-kube-scheduler-operator")
+}
+
+func testSchedulerNetworkPolicyReconcile() {
+	ctx := context.Background()
+	g.By("Creating Kubernetes clients")
+	kubeConfig, err := test.NewClientConfigForTest()
+	o.Expect(err).NotTo(o.HaveOccurred())
+	kubeClient, err := kubernetes.NewForConfig(kubeConfig)
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	g.By("Waiting for kube scheduler operator to be ready")
+	err = test.WaitForOperator(ctx, kubeClient)
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	g.By("Capturing expected NetworkPolicy specs across all namespaces")
+	expectedSchedulerPolicy := getNetworkPolicy(ctx, kubeClient, schedulerNamespace, schedulerPolicyName)
+	expectedSchedulerDefaultDeny := getNetworkPolicy(ctx, kubeClient, schedulerNamespace, defaultDenyAllPolicyName)
+	expectedSchedulerOperatorPolicy := getNetworkPolicy(ctx, kubeClient, schedulerOperatorNamespace, schedulerOperatorPolicyName)
+	expectedSchedulerOperatorDefaultDeny := getNetworkPolicy(ctx, kubeClient, schedulerOperatorNamespace, defaultDenyAllPolicyName)
+
+	g.By("Deleting all NetworkPolicies simultaneously and waiting for restoration")
+	policiesToDelete := []*networkingv1.NetworkPolicy{
+		expectedSchedulerPolicy,
+		expectedSchedulerDefaultDeny,
+		expectedSchedulerOperatorPolicy,
+		expectedSchedulerOperatorDefaultDeny,
+	}
+	deleteAndWaitForAllRestored(ctx, kubeClient, policiesToDelete)
+
+	g.By("Mutating all NetworkPolicies simultaneously and waiting for reconciliation")
+	policiesToMutate := []struct{ namespace, name string }{
+		{schedulerNamespace, schedulerPolicyName},
+		{schedulerNamespace, defaultDenyAllPolicyName},
+		{schedulerOperatorNamespace, schedulerOperatorPolicyName},
+		{schedulerOperatorNamespace, defaultDenyAllPolicyName},
+	}
+	mutateAndWaitForAllReconciled(ctx, kubeClient, policiesToMutate)
+
+	g.By("Checking NetworkPolicy-related events (best-effort)")
+	logNetworkPolicyEvents(ctx, kubeClient, []string{"openshift-kube-scheduler-operator", schedulerNamespace}, schedulerPolicyName)
+
+	g.By("Waiting for kube-scheduler ClusterOperator to stabilize after reconciliation")
+	configClient, err := test.NewConfigClient()
+	o.Expect(err).NotTo(o.HaveOccurred())
+	err = test.WaitForClusterOperatorStable(ctx, configClient)
+	o.Expect(err).NotTo(o.HaveOccurred())
+}

--- a/test/e2e/network_policy_enforcement.go
+++ b/test/e2e/network_policy_enforcement.go
@@ -1,0 +1,219 @@
+package e2e
+
+import (
+	"context"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/client-go/kubernetes"
+
+	test "github.com/openshift/cluster-kube-scheduler-operator/test/library"
+)
+
+var _ = g.Describe("[sig-scheduling] kube scheduler operator", func() {
+	g.It("[NetworkPolicy] should enforce generic NetworkPolicies", func() {
+		testGenericNetworkPolicyEnforcement()
+	})
+	g.It("[NetworkPolicy] should enforce kube scheduler NetworkPolicies", func() {
+		testSchedulerNetworkPolicyEnforcement()
+	})
+	g.It("[NetworkPolicy] should enforce cross-namespace ingress traffic", func() {
+		testCrossNamespaceIngressEnforcement()
+	})
+	g.It("[NetworkPolicy] should allow metrics but block other ports", func() {
+		testMetricsOpenButOtherPortsBlocked()
+	})
+	g.It("[NetworkPolicy] should allow metrics ingress from any namespace", func() {
+		testMetricsIngressOpenAccess()
+	})
+})
+
+func testGenericNetworkPolicyEnforcement() {
+	ctx := context.Background()
+	kubeConfig, err := test.NewClientConfigForTest()
+	o.Expect(err).NotTo(o.HaveOccurred())
+	kubeClient, err := kubernetes.NewForConfig(kubeConfig)
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	g.By("Creating a temporary namespace for policy enforcement checks")
+	nsName := "np-enforcement-" + rand.String(5)
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: nsName}}
+	_, err = kubeClient.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred())
+	g.DeferCleanup(func() {
+		g.GinkgoWriter.Printf("deleting test namespace %s\n", nsName)
+		_ = kubeClient.CoreV1().Namespaces().Delete(ctx, nsName, metav1.DeleteOptions{})
+	})
+
+	serverName := "np-server"
+	clientLabels := map[string]string{"app": "np-client"}
+	serverLabels := map[string]string{"app": "np-server"}
+
+	g.GinkgoWriter.Printf("creating netexec server pod %s/%s\n", nsName, serverName)
+	serverPod := netexecPod(serverName, nsName, serverLabels, 8080)
+	_, err = kubeClient.CoreV1().Pods(nsName).Create(ctx, serverPod, metav1.CreateOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred())
+	o.Expect(waitForPodReady(ctx, kubeClient, nsName, serverName)).NotTo(o.HaveOccurred())
+
+	server, err := kubeClient.CoreV1().Pods(nsName).Get(ctx, serverName, metav1.GetOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred())
+	o.Expect(server.Status.PodIPs).NotTo(o.BeEmpty())
+	serverIPs := podIPs(server)
+	g.GinkgoWriter.Printf("server pod %s/%s ips=%v\n", nsName, serverName, serverIPs)
+
+	g.By("Verifying allow-all when no policies select the pod")
+	expectConnectivity(ctx, kubeClient, nsName, clientLabels, serverIPs, 8080, true)
+
+	g.By("Applying default deny and verifying traffic is blocked")
+	g.GinkgoWriter.Printf("creating default-deny policy in %s\n", nsName)
+	_, err = kubeClient.NetworkingV1().NetworkPolicies(nsName).Create(ctx, defaultDenyPolicy("default-deny", nsName), metav1.CreateOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	g.By("Adding ingress allow only and verifying traffic is still blocked")
+	g.GinkgoWriter.Printf("creating allow-ingress policy in %s\n", nsName)
+	_, err = kubeClient.NetworkingV1().NetworkPolicies(nsName).Create(ctx, allowIngressPolicy("allow-ingress", nsName, serverLabels, clientLabels, 8080), metav1.CreateOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred())
+	expectConnectivity(ctx, kubeClient, nsName, clientLabels, serverIPs, 8080, false)
+
+	g.By("Adding egress allow and verifying traffic is permitted")
+	g.GinkgoWriter.Printf("creating allow-egress policy in %s\n", nsName)
+	_, err = kubeClient.NetworkingV1().NetworkPolicies(nsName).Create(ctx, allowEgressPolicy("allow-egress", nsName, clientLabels, serverLabels, 8080), metav1.CreateOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred())
+	expectConnectivity(ctx, kubeClient, nsName, clientLabels, serverIPs, 8080, true)
+}
+
+func testSchedulerNetworkPolicyEnforcement() {
+	ctx := context.Background()
+	kubeConfig, err := test.NewClientConfigForTest()
+	o.Expect(err).NotTo(o.HaveOccurred())
+	kubeClient, err := kubernetes.NewForConfig(kubeConfig)
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	schedulerOperatorLabels := map[string]string{"app": "openshift-kube-scheduler-operator"}
+
+	g.By("Verifying kube-scheduler-operator NetworkPolicy exists")
+	_, err = kubeClient.NetworkingV1().NetworkPolicies(schedulerOperatorNamespace).Get(ctx, "kube-scheduler-operator", metav1.GetOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	g.By("Creating test pods in openshift-kube-scheduler-operator for allow/deny checks")
+	g.GinkgoWriter.Printf("creating scheduler operator server pods in %s\n", schedulerOperatorNamespace)
+	allowedServerIPs, cleanupAllowed := createServerPod(ctx, kubeClient, schedulerOperatorNamespace, "np-scheduler-op-allowed", schedulerOperatorLabels, 8443)
+	g.DeferCleanup(cleanupAllowed)
+	deniedServerIPs, cleanupDenied := createServerPod(ctx, kubeClient, schedulerOperatorNamespace, "np-scheduler-op-denied", schedulerOperatorLabels, 12345)
+	g.DeferCleanup(cleanupDenied)
+
+	g.By("Verifying allowed port 8443 ingress to scheduler operator")
+	expectConnectivity(ctx, kubeClient, schedulerOperatorNamespace, schedulerOperatorLabels, allowedServerIPs, 8443, true)
+
+	g.By("Verifying denied port 12345 (not in NetworkPolicy)")
+	expectConnectivity(ctx, kubeClient, schedulerOperatorNamespace, schedulerOperatorLabels, deniedServerIPs, 12345, false)
+
+	g.By("Verifying denied ports even from same namespace")
+	for _, port := range []int32{80, 443, 6443, 9090} {
+		expectConnectivity(ctx, kubeClient, schedulerOperatorNamespace, schedulerOperatorLabels, allowedServerIPs, port, false)
+	}
+
+	g.By("Verifying scheduler operator egress to DNS")
+	dnsSvc, err := kubeClient.CoreV1().Services("openshift-dns").Get(ctx, "dns-default", metav1.GetOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred())
+	dnsIPs := serviceClusterIPs(dnsSvc)
+	g.GinkgoWriter.Printf("expecting allow from %s to DNS %v:53\n", schedulerOperatorNamespace, dnsIPs)
+	expectConnectivity(ctx, kubeClient, schedulerOperatorNamespace, schedulerOperatorLabels, dnsIPs, 53, true)
+
+	g.By("Verifying scheduler pods egress (installer/pruner policy)")
+	installerLabels := map[string]string{"app": "installer"}
+	expectConnectivity(ctx, kubeClient, schedulerNamespace, installerLabels, dnsIPs, 53, true)
+}
+
+func testCrossNamespaceIngressEnforcement() {
+	ctx := context.Background()
+	kubeConfig, err := test.NewClientConfigForTest()
+	o.Expect(err).NotTo(o.HaveOccurred())
+	kubeClient, err := kubernetes.NewForConfig(kubeConfig)
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	g.By("Creating test server pods in kube-scheduler-operator namespace")
+	schedulerOpLabels := map[string]string{"app": "openshift-kube-scheduler-operator"}
+	schedulerOpIPs, cleanupSchedulerOp := createServerPod(ctx, kubeClient, schedulerOperatorNamespace, "np-scheduler-op-xns", schedulerOpLabels, 8443)
+	g.DeferCleanup(cleanupSchedulerOp)
+
+	g.By("Testing cross-namespace ingress: monitoring -> kube-scheduler-operator:8443")
+	g.GinkgoWriter.Printf("expecting allow from openshift-monitoring to %v:8443\n", schedulerOpIPs)
+	expectConnectivity(ctx, kubeClient, "openshift-monitoring", map[string]string{"app.kubernetes.io/name": "prometheus"}, schedulerOpIPs, 8443, true)
+
+	g.By("Testing cross-namespace ingress: any pod from monitoring can access metrics")
+	g.GinkgoWriter.Printf("expecting allow from openshift-monitoring with any labels to %v:8443\n", schedulerOpIPs)
+	expectConnectivity(ctx, kubeClient, "openshift-monitoring", map[string]string{"app": "any-label"}, schedulerOpIPs, 8443, true)
+}
+
+func testMetricsOpenButOtherPortsBlocked() {
+	ctx := context.Background()
+	kubeConfig, err := test.NewClientConfigForTest()
+	o.Expect(err).NotTo(o.HaveOccurred())
+	kubeClient, err := kubernetes.NewForConfig(kubeConfig)
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	g.By("Creating test server pod in kube-scheduler-operator namespace")
+	schedulerOpLabels := map[string]string{"app": "openshift-kube-scheduler-operator"}
+	schedulerOpIPs, cleanupSchedulerOp := createServerPod(ctx, kubeClient, schedulerOperatorNamespace, "np-scheduler-op-unauth", schedulerOpLabels, 8443)
+	g.DeferCleanup(cleanupSchedulerOp)
+
+	g.By("Testing metrics port 8443 is open: default namespace -> kube-scheduler-operator:8443")
+	g.GinkgoWriter.Printf("expecting allow from default to %v:8443 (metrics open to all)\n", schedulerOpIPs)
+	expectConnectivity(ctx, kubeClient, "default", map[string]string{"test": "client"}, schedulerOpIPs, 8443, true)
+
+	g.By("Testing metrics port 8443 from openshift-etcd with custom app label: should be denied")
+	g.GinkgoWriter.Printf("expecting deny from openshift-etcd with custom label to %v:8443 (custom app labels not allowed in etcd namespace)\n", schedulerOpIPs)
+	expectConnectivity(ctx, kubeClient, "openshift-etcd", map[string]string{"test": "client"}, schedulerOpIPs, 8443, false)
+
+	g.By("Testing port-based blocking: unauthorized ports are still blocked")
+	g.GinkgoWriter.Printf("expecting deny from openshift-monitoring to %v:9999 (unauthorized port)\n", schedulerOpIPs)
+	expectConnectivity(ctx, kubeClient, "openshift-monitoring", map[string]string{"app.kubernetes.io/name": "prometheus"}, schedulerOpIPs, 9999, false)
+
+	g.By("Testing multiple unauthorized ports are still blocked by default-deny")
+	for _, port := range []int32{80, 443, 8080, 22, 3306, 9090} {
+		g.GinkgoWriter.Printf("expecting deny from default to %v:%d (unauthorized port)\n", schedulerOpIPs, port)
+		expectConnectivity(ctx, kubeClient, "default", map[string]string{"test": "any-pod"}, schedulerOpIPs, port, false)
+	}
+}
+
+func testMetricsIngressOpenAccess() {
+	ctx := context.Background()
+	kubeConfig, err := test.NewClientConfigForTest()
+	o.Expect(err).NotTo(o.HaveOccurred())
+	kubeClient, err := kubernetes.NewForConfig(kubeConfig)
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	g.By("Creating test server pod in kube-scheduler-operator namespace with operator labels")
+	schedulerOpLabels := map[string]string{"app": "openshift-kube-scheduler-operator"}
+	schedulerOpIPs, cleanupSchedulerOp := createServerPod(ctx, kubeClient, schedulerOperatorNamespace, "np-metrics-test", schedulerOpLabels, 8443)
+	g.DeferCleanup(cleanupSchedulerOp)
+
+	g.By("Testing metrics policy: monitoring namespace can access metrics -> operator:8443")
+	g.GinkgoWriter.Printf("expecting allow from openshift-monitoring to %v:8443\n", schedulerOpIPs)
+	expectConnectivity(ctx, kubeClient, "openshift-monitoring", map[string]string{"app.kubernetes.io/name": "prometheus"}, schedulerOpIPs, 8443, true)
+
+	g.By("Testing metrics policy: etcd namespace with custom app label should be denied")
+	g.GinkgoWriter.Printf("expecting deny from openshift-etcd with custom label to %v:8443 (custom app labels not allowed in etcd namespace)\n", schedulerOpIPs)
+	expectConnectivity(ctx, kubeClient, "openshift-etcd", map[string]string{"test": "metrics-client"}, schedulerOpIPs, 8443, false)
+
+	g.By("Testing metrics policy: console namespace with custom app label can access metrics")
+	g.GinkgoWriter.Printf("expecting allow from openshift-console with custom label to %v:8443 (metrics open to most namespaces)\n", schedulerOpIPs)
+	expectConnectivity(ctx, kubeClient, "openshift-console", map[string]string{"custom-app": "test-client"}, schedulerOpIPs, 8443, true)
+
+	g.By("Testing metrics policy: default namespace can access metrics -> operator:8443")
+	g.GinkgoWriter.Printf("expecting allow from default namespace to %v:8443\n", schedulerOpIPs)
+	expectConnectivity(ctx, kubeClient, "default", map[string]string{"test": "client"}, schedulerOpIPs, 8443, true)
+
+	g.By("Testing metrics policy: same namespace can access metrics -> operator:8443")
+	g.GinkgoWriter.Printf("expecting allow from openshift-kube-scheduler-operator to %v:8443 (same namespace)\n", schedulerOpIPs)
+	expectConnectivity(ctx, kubeClient, schedulerOperatorNamespace, map[string]string{"app": "openshift-kube-scheduler-operator"}, schedulerOpIPs, 8443, true)
+
+	g.By("Testing default-deny still blocks unauthorized ports")
+	g.GinkgoWriter.Printf("expecting deny from openshift-monitoring to %v:9090 (wrong port, not allowed by any policy)\n", schedulerOpIPs)
+	expectConnectivity(ctx, kubeClient, "openshift-monitoring", map[string]string{"app.kubernetes.io/name": "prometheus"}, schedulerOpIPs, 9090, false)
+}

--- a/test/e2e/network_policy_enforcement.go
+++ b/test/e2e/network_policy_enforcement.go
@@ -1,0 +1,221 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/client-go/kubernetes"
+
+	test "github.com/openshift/cluster-kube-scheduler-operator/test/library"
+)
+
+var _ = g.Describe("[sig-scheduling] kube scheduler operator", func() {
+	g.It("[NetworkPolicy][Operator][Parallel] should enforce generic NetworkPolicies", func() {
+		testGenericNetworkPolicyEnforcement()
+	})
+	g.It("[NetworkPolicy][Operator][Parallel] should enforce kube scheduler NetworkPolicies", func() {
+		testSchedulerNetworkPolicyEnforcement()
+	})
+	g.It("[NetworkPolicy][Operator][Parallel] should enforce cross-namespace ingress traffic", func() {
+		testCrossNamespaceIngressEnforcement()
+	})
+	g.It("[NetworkPolicy][Operator][Parallel] should allow metrics but block other ports", func() {
+		testMetricsOpenButOtherPortsBlocked()
+	})
+	g.It("[NetworkPolicy][Operator][Parallel] should allow metrics ingress from any namespace", func() {
+		testMetricsIngressOpenAccess()
+	})
+})
+
+func testGenericNetworkPolicyEnforcement() {
+	ctx := context.Background()
+	kubeConfig, err := test.NewClientConfigForTest()
+	o.Expect(err).NotTo(o.HaveOccurred())
+	kubeClient, err := kubernetes.NewForConfig(kubeConfig)
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	g.By("Creating a temporary namespace for policy enforcement checks")
+	nsName := "np-enforcement-" + rand.String(5)
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: nsName}}
+	_, err = kubeClient.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred())
+	g.DeferCleanup(func() {
+		g.GinkgoWriter.Printf("deleting test namespace %s\n", nsName)
+		_ = kubeClient.CoreV1().Namespaces().Delete(ctx, nsName, metav1.DeleteOptions{})
+	})
+
+	serverName := fmt.Sprintf("np-server-%s", rand.String(5))
+	clientLabels := map[string]string{"app": "np-client"}
+	serverLabels := map[string]string{"app": "np-server"}
+
+	g.GinkgoWriter.Printf("creating netexec server pod %s/%s\n", nsName, serverName)
+	serverIPs, cleanupServer := createServerPod(ctx, kubeClient, nsName, serverName, serverLabels, 8080)
+	g.DeferCleanup(cleanupServer)
+
+	g.By("Verifying allow-all when no policies select the pod")
+	expectConnectivity(ctx, kubeClient, nsName, clientLabels, serverIPs, 8080, true)
+
+	g.By("Applying default deny and verifying traffic is blocked")
+	g.GinkgoWriter.Printf("creating default-deny policy in %s\n", nsName)
+	_, err = kubeClient.NetworkingV1().NetworkPolicies(nsName).Create(ctx, defaultDenyPolicy("default-deny", nsName), metav1.CreateOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	g.By("Adding ingress allow only and verifying traffic is still blocked")
+	g.GinkgoWriter.Printf("creating allow-ingress policy in %s\n", nsName)
+	_, err = kubeClient.NetworkingV1().NetworkPolicies(nsName).Create(ctx, allowIngressPolicy("allow-ingress", nsName, serverLabels, clientLabels, 8080), metav1.CreateOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred())
+	expectConnectivity(ctx, kubeClient, nsName, clientLabels, serverIPs, 8080, false)
+
+	g.By("Adding egress allow and verifying traffic is permitted")
+	g.GinkgoWriter.Printf("creating allow-egress policy in %s\n", nsName)
+	_, err = kubeClient.NetworkingV1().NetworkPolicies(nsName).Create(ctx, allowEgressPolicy("allow-egress", nsName, clientLabels, serverLabels, 8080), metav1.CreateOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred())
+	expectConnectivity(ctx, kubeClient, nsName, clientLabels, serverIPs, 8080, true)
+}
+
+func testSchedulerNetworkPolicyEnforcement() {
+	ctx := context.Background()
+	kubeConfig, err := test.NewClientConfigForTest()
+	o.Expect(err).NotTo(o.HaveOccurred())
+	kubeClient, err := kubernetes.NewForConfig(kubeConfig)
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	schedulerOperatorLabels := map[string]string{"app": "openshift-kube-scheduler-operator"}
+
+	g.By("Verifying kube-scheduler-operator NetworkPolicy exists")
+	_, err = kubeClient.NetworkingV1().NetworkPolicies(schedulerOperatorNamespace).Get(ctx, "kube-scheduler-operator", metav1.GetOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	g.By("Creating test pods in openshift-kube-scheduler-operator for allow/deny checks")
+	g.GinkgoWriter.Printf("creating scheduler operator server pods in %s\n", schedulerOperatorNamespace)
+	allowedServerIPs, cleanupAllowed := createServerPod(ctx, kubeClient, schedulerOperatorNamespace, fmt.Sprintf("np-scheduler-op-allowed-%s", rand.String(5)), schedulerOperatorLabels, 8443)
+	g.DeferCleanup(cleanupAllowed)
+	deniedServerIPs, cleanupDenied := createServerPod(ctx, kubeClient, schedulerOperatorNamespace, fmt.Sprintf("np-scheduler-op-denied-%s", rand.String(5)), schedulerOperatorLabels, 12345)
+	g.DeferCleanup(cleanupDenied)
+
+	g.By("Verifying allowed port 8443 ingress to scheduler operator")
+	expectConnectivity(ctx, kubeClient, schedulerOperatorNamespace, schedulerOperatorLabels, allowedServerIPs, 8443, true)
+
+	g.By("Verifying denied port 12345 (not in NetworkPolicy)")
+	expectConnectivity(ctx, kubeClient, schedulerOperatorNamespace, schedulerOperatorLabels, deniedServerIPs, 12345, false)
+
+	g.By("Verifying denied ports even from same namespace")
+	for _, port := range []int32{80, 443, 6443, 9090} {
+		expectConnectivity(ctx, kubeClient, schedulerOperatorNamespace, schedulerOperatorLabels, allowedServerIPs, port, false)
+	}
+
+	g.By("Verifying scheduler operator egress to DNS pods on port 5353 (metrics)")
+	dnsPods, err := kubeClient.CoreV1().Pods("openshift-dns").List(ctx, metav1.ListOptions{
+		LabelSelector: "dns.operator.openshift.io/daemonset-dns=default",
+	})
+	o.Expect(err).NotTo(o.HaveOccurred())
+	o.Expect(dnsPods.Items).NotTo(o.BeEmpty(), "expected to find DNS pods")
+	dnsPodIPs := []string{}
+	for _, pod := range dnsPods.Items {
+		if pod.Status.PodIP != "" {
+			dnsPodIPs = append(dnsPodIPs, pod.Status.PodIP)
+		}
+	}
+	o.Expect(dnsPodIPs).NotTo(o.BeEmpty(), "expected DNS pods to have IPs")
+	g.GinkgoWriter.Printf("expecting allow from %s to DNS pods %v:5353\n", schedulerOperatorNamespace, dnsPodIPs)
+	expectConnectivity(ctx, kubeClient, schedulerOperatorNamespace, schedulerOperatorLabels, dnsPodIPs, 5353, true)
+
+	g.By("Verifying scheduler installer/pruner pods egress to DNS pods on port 5353 (metrics)")
+	installerLabels := map[string]string{"app": "installer"}
+	expectConnectivity(ctx, kubeClient, schedulerNamespace, installerLabels, dnsPodIPs, 5353, true)
+}
+
+func testCrossNamespaceIngressEnforcement() {
+	ctx := context.Background()
+	kubeConfig, err := test.NewClientConfigForTest()
+	o.Expect(err).NotTo(o.HaveOccurred())
+	kubeClient, err := kubernetes.NewForConfig(kubeConfig)
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	g.By("Creating test server pods in kube-scheduler-operator namespace")
+	schedulerOpLabels := map[string]string{"app": "openshift-kube-scheduler-operator"}
+	schedulerOpIPs, cleanupSchedulerOp := createServerPod(ctx, kubeClient, schedulerOperatorNamespace, fmt.Sprintf("np-scheduler-op-xns-%s", rand.String(5)), schedulerOpLabels, 8443)
+	g.DeferCleanup(cleanupSchedulerOp)
+
+	g.By("Testing cross-namespace ingress: monitoring -> kube-scheduler-operator:8443")
+	g.GinkgoWriter.Printf("expecting allow from openshift-monitoring to %v:8443\n", schedulerOpIPs)
+	expectConnectivity(ctx, kubeClient, "openshift-monitoring", map[string]string{"app.kubernetes.io/name": "prometheus"}, schedulerOpIPs, 8443, true)
+
+	g.By("Testing cross-namespace ingress: any pod from monitoring can access metrics")
+	g.GinkgoWriter.Printf("expecting allow from openshift-monitoring with any labels to %v:8443\n", schedulerOpIPs)
+	expectConnectivity(ctx, kubeClient, "openshift-monitoring", map[string]string{"app": "any-label"}, schedulerOpIPs, 8443, true)
+}
+
+func testMetricsOpenButOtherPortsBlocked() {
+	ctx := context.Background()
+	kubeConfig, err := test.NewClientConfigForTest()
+	o.Expect(err).NotTo(o.HaveOccurred())
+	kubeClient, err := kubernetes.NewForConfig(kubeConfig)
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	g.By("Creating test server pod in kube-scheduler-operator namespace")
+	schedulerOpLabels := map[string]string{"app": "openshift-kube-scheduler-operator"}
+	schedulerOpIPs, cleanupSchedulerOp := createServerPod(ctx, kubeClient, schedulerOperatorNamespace, fmt.Sprintf("np-scheduler-op-unauth-%s", rand.String(5)), schedulerOpLabels, 8443)
+	g.DeferCleanup(cleanupSchedulerOp)
+
+	g.By("Testing metrics port 8443 is open: default namespace -> kube-scheduler-operator:8443")
+	g.GinkgoWriter.Printf("expecting allow from default to %v:8443 (metrics open to all)\n", schedulerOpIPs)
+	expectConnectivity(ctx, kubeClient, "default", map[string]string{"test": "client"}, schedulerOpIPs, 8443, true)
+
+	g.By("Testing etcd namespace: etcd's own default-deny-all takes precedence over scheduler operator's allow")
+	g.GinkgoWriter.Printf("expecting deny from openshift-etcd to %v:8443 (etcd namespace has default-deny-all egress that blocks this)\n", schedulerOpIPs)
+	expectConnectivity(ctx, kubeClient, "openshift-etcd", map[string]string{"test": "client"}, schedulerOpIPs, 8443, false)
+
+	g.By("Testing port-based blocking: unauthorized ports are still blocked")
+	g.GinkgoWriter.Printf("expecting deny from openshift-monitoring to %v:9999 (unauthorized port)\n", schedulerOpIPs)
+	expectConnectivity(ctx, kubeClient, "openshift-monitoring", map[string]string{"app.kubernetes.io/name": "prometheus"}, schedulerOpIPs, 9999, false)
+
+	g.By("Testing multiple unauthorized ports are still blocked by default-deny")
+	for _, port := range []int32{80, 443, 8080, 22, 3306, 9090} {
+		g.GinkgoWriter.Printf("expecting deny from default to %v:%d (unauthorized port)\n", schedulerOpIPs, port)
+		expectConnectivity(ctx, kubeClient, "default", map[string]string{"test": "any-pod"}, schedulerOpIPs, port, false)
+	}
+}
+
+func testMetricsIngressOpenAccess() {
+	ctx := context.Background()
+	kubeConfig, err := test.NewClientConfigForTest()
+	o.Expect(err).NotTo(o.HaveOccurred())
+	kubeClient, err := kubernetes.NewForConfig(kubeConfig)
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	g.By("Creating test server pod in kube-scheduler-operator namespace with operator labels")
+	schedulerOpLabels := map[string]string{"app": "openshift-kube-scheduler-operator"}
+	schedulerOpIPs, cleanupSchedulerOp := createServerPod(ctx, kubeClient, schedulerOperatorNamespace, fmt.Sprintf("np-metrics-test-%s", rand.String(5)), schedulerOpLabels, 8443)
+	g.DeferCleanup(cleanupSchedulerOp)
+
+	g.By("Testing metrics policy: monitoring namespace can access metrics -> operator:8443")
+	g.GinkgoWriter.Printf("expecting allow from openshift-monitoring to %v:8443\n", schedulerOpIPs)
+	expectConnectivity(ctx, kubeClient, "openshift-monitoring", map[string]string{"app.kubernetes.io/name": "prometheus"}, schedulerOpIPs, 8443, true)
+
+	g.By("Testing etcd namespace: etcd's own default-deny-all egress policy blocks access despite scheduler operator's ingress allow")
+	g.GinkgoWriter.Printf("expecting deny from openshift-etcd to %v:8443 (etcd namespace has default-deny-all egress that blocks this)\n", schedulerOpIPs)
+	expectConnectivity(ctx, kubeClient, "openshift-etcd", map[string]string{"test": "metrics-client"}, schedulerOpIPs, 8443, false)
+
+	g.By("Testing metrics policy: console namespace with custom app label can access metrics")
+	g.GinkgoWriter.Printf("expecting allow from openshift-console with custom label to %v:8443 (metrics open to most namespaces)\n", schedulerOpIPs)
+	expectConnectivity(ctx, kubeClient, "openshift-console", map[string]string{"custom-app": "test-client"}, schedulerOpIPs, 8443, true)
+
+	g.By("Testing metrics policy: default namespace can access metrics -> operator:8443")
+	g.GinkgoWriter.Printf("expecting allow from default namespace to %v:8443\n", schedulerOpIPs)
+	expectConnectivity(ctx, kubeClient, "default", map[string]string{"test": "client"}, schedulerOpIPs, 8443, true)
+
+	g.By("Testing metrics policy: same namespace can access metrics -> operator:8443")
+	g.GinkgoWriter.Printf("expecting allow from openshift-kube-scheduler-operator to %v:8443 (same namespace)\n", schedulerOpIPs)
+	expectConnectivity(ctx, kubeClient, schedulerOperatorNamespace, map[string]string{"app": "openshift-kube-scheduler-operator"}, schedulerOpIPs, 8443, true)
+
+	g.By("Testing default-deny still blocks unauthorized ports")
+	g.GinkgoWriter.Printf("expecting deny from openshift-monitoring to %v:9090 (wrong port, not allowed by any policy)\n", schedulerOpIPs)
+	expectConnectivity(ctx, kubeClient, "openshift-monitoring", map[string]string{"app.kubernetes.io/name": "prometheus"}, schedulerOpIPs, 9090, false)
+}

--- a/test/library/client.go
+++ b/test/library/client.go
@@ -2,6 +2,8 @@ package library
 
 import (
 	"fmt"
+
+	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/clientcmd/api"
@@ -16,4 +18,13 @@ func NewClientConfigForTest() (*rest.Config, error) {
 		fmt.Printf("Found configuration for host %v.\n", config.Host)
 	}
 	return config, err
+}
+
+// NewConfigClient returns a config client for accessing OpenShift ClusterOperator resources
+func NewConfigClient() (configv1client.ConfigV1Interface, error) {
+	config, err := NewClientConfigForTest()
+	if err != nil {
+		return nil, err
+	}
+	return configv1client.NewForConfig(config)
 }

--- a/test/library/utils.go
+++ b/test/library/utils.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"time"
 
+	configv1 "github.com/openshift/api/config/v1"
+	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -33,5 +35,27 @@ func WaitForOperator(ctx context.Context, kclient kubernetes.Interface) error {
 		}
 		klog.Infof("deployment is not yet available: %#v\n", d)
 		return false, nil
+	})
+}
+
+// WaitForClusterOperatorStable waits for the kube-scheduler ClusterOperator to be non-progressing
+func WaitForClusterOperatorStable(ctx context.Context, configClient configv1client.ConfigV1Interface) error {
+	return wait.PollImmediate(5*time.Second, 10*time.Minute, func() (bool, error) {
+		co, err := configClient.ClusterOperators().Get(ctx, "kube-scheduler", metav1.GetOptions{})
+		if err != nil {
+			klog.Infof("error getting clusteroperator: %v\n", err)
+			return false, nil
+		}
+
+		for _, condition := range co.Status.Conditions {
+			if condition.Type == configv1.OperatorProgressing {
+				if condition.Status == configv1.ConditionTrue {
+					klog.Infof("cluster operator still progressing: %s\n", condition.Message)
+					return false, nil
+				}
+				return true, nil
+			}
+		}
+		return false, fmt.Errorf("progressing condition not found")
 	})
 }


### PR DESCRIPTION
network policy tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive end-to-end tests for NetworkPolicy validation, enforcement, reconciliation and connectivity for the kube-scheduler operator, covering default-deny, ingress/egress rules, cross-namespace scenarios, metrics access, DNS egress, and reconciliation after deletions/mutations.
  * Added test utilities for deterministic connectivity checks, long-running probes, pod/service readiness and IP discovery, selector/rule validation, and policy-related logging.
* **Chores**
  * Increased e2e test timeout to 1 hour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->