### PR TITLE
OCPBUGS-82503: add /var/run/kubernetes as emptyDir

### DIFF
--- a/bindata/assets/kube-scheduler/pod.yaml
+++ b/bindata/assets/kube-scheduler/pod.yaml
@@ -51,6 +51,8 @@ spec:
       name: resource-dir
     - mountPath: /etc/kubernetes/static-pod-certs
       name: cert-dir
+    - mountPath: /var/run/kubernetes
+      name: var-run-kubernetes
     livenessProbe:
       httpGet:
         scheme: HTTPS
@@ -127,3 +129,5 @@ spec:
   - hostPath:
       path: /etc/kubernetes/static-pod-resources/kube-scheduler-certs
     name: cert-dir
+  - emptyDir: {}
+    name: var-run-kubernetes

--- a/bindata/bootkube/bootstrap-manifests/kube-scheduler-pod.yaml
+++ b/bindata/bootkube/bootstrap-manifests/kube-scheduler-pod.yaml
@@ -32,6 +32,8 @@ spec:
       readOnly: true
     - mountPath: /var/log/bootstrap-control-plane
       name: logs
+    - mountPath: /var/run/kubernetes
+      name: var-run-kubernetes
   hostNetwork: true
   volumes:
   - hostPath:
@@ -40,3 +42,5 @@ spec:
   - hostPath:
       path: /var/log/bootstrap-control-plane
     name: logs
+  - emptyDir: {}
+    name: var-run-kubernetes

--- a/pkg/operator/targetconfigcontroller/testdata/ks_pod_scenario_1.yaml
+++ b/pkg/operator/targetconfigcontroller/testdata/ks_pod_scenario_1.yaml
@@ -20,6 +20,8 @@ spec:
     - name: cert-dir
       hostPath:
         path: "/etc/kubernetes/static-pod-resources/kube-scheduler-certs"
+    - name: var-run-kubernetes
+      emptyDir: {}
   initContainers:
     - name: wait-for-host-port
       image: CaptainAmerica
@@ -65,6 +67,8 @@ spec:
           mountPath: "/etc/kubernetes/static-pod-resources"
         - name: cert-dir
           mountPath: "/etc/kubernetes/static-pod-certs"
+        - name: var-run-kubernetes
+          mountPath: "/var/run/kubernetes"
       livenessProbe:
         httpGet:
           path: healthz

--- a/pkg/operator/targetconfigcontroller/testdata/ks_pod_scenario_2.yaml
+++ b/pkg/operator/targetconfigcontroller/testdata/ks_pod_scenario_2.yaml
@@ -20,6 +20,8 @@ spec:
     - name: cert-dir
       hostPath:
         path: "/etc/kubernetes/static-pod-resources/kube-scheduler-certs"
+    - name: var-run-kubernetes
+      emptyDir: {}
   initContainers:
     - name: wait-for-host-port
       image: CaptainAmerica
@@ -66,6 +68,8 @@ spec:
           mountPath: "/etc/kubernetes/static-pod-resources"
         - name: cert-dir
           mountPath: "/etc/kubernetes/static-pod-certs"
+        - name: var-run-kubernetes
+          mountPath: "/var/run/kubernetes"
       livenessProbe:
         httpGet:
           path: healthz

--- a/pkg/operator/targetconfigcontroller/testdata/ks_pod_scenario_3.yaml
+++ b/pkg/operator/targetconfigcontroller/testdata/ks_pod_scenario_3.yaml
@@ -20,6 +20,8 @@ spec:
     - name: cert-dir
       hostPath:
         path: "/etc/kubernetes/static-pod-resources/kube-scheduler-certs"
+    - name: var-run-kubernetes
+      emptyDir: {}
   initContainers:
     - name: wait-for-host-port
       image: CaptainAmerica
@@ -67,6 +69,8 @@ spec:
           mountPath: "/etc/kubernetes/static-pod-resources"
         - name: cert-dir
           mountPath: "/etc/kubernetes/static-pod-certs"
+        - name: var-run-kubernetes
+          mountPath: "/var/run/kubernetes"
       livenessProbe:
         httpGet:
           path: healthz


### PR DESCRIPTION
In some cases, the scheduler can fall back to self-signing its certificate and it tries to mkdir `/var/run/kubernetes` which fails due to `readOnlyRootFilesystem` being enabled. This PR mounts this directory as emptyDir so that it's writable and the signing process and proceed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Configured ephemeral volume storage for kube-scheduler's certificate directory, ensuring proper read-write access to runtime certificate materials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->