### PR TITLE
NO-JIRA: Add control-plane-approvers to OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,7 +1,5 @@
 reviewers:
-  - ingvagabund
-  - ricardomaraschini
+  - control-plane-approvers
 approvers:
-  - ingvagabund
-  - ricardomaraschini
+  - control-plane-approvers
 component: "kube-scheduler"

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,16 @@
+aliases:
+  control-plane-approvers:
+    - ardaguclu
+    - atiratree
+    - benluddy
+    - bertinatto
+    - everettraven
+    - flavianmissi
+    - gangwgr
+    - ingvagabund
+    - kaleemsiddiqu
+    - p0lyn0mial
+    - rh-roman
+    - ricardomaraschini
+    - tjungblu
+    - xueqzhan


### PR DESCRIPTION
Add control-plane-approvers to OWNERS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated reviewer and approver configuration for component code governance and team organization.
  * Added a new group alias to centralize and streamline code review access management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->