### PR TITLE
OCPBUGS-99295: add required-scc annotation to operator deployment pod

### DIFF
--- a/manifests/0000_25_kube-scheduler-operator_06_deployment.yaml
+++ b/manifests/0000_25_kube-scheduler-operator_06_deployment.yaml
@@ -19,6 +19,7 @@ spec:
       name: openshift-kube-scheduler-operator
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        openshift.io/required-scc: restricted-v2
       labels:
         app: openshift-kube-scheduler-operator
     spec:


### PR DESCRIPTION
This PR fixes the location of the required-scc annotation in the periodic-gathering job pod template

Add openshift.io/required-scc: restricted-v2 annotation to the kube-scheduler-operator deployment pod template to satisfy the SCC pinning requirement and resolve the flaking sig-auth test.

Failure job: https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-shiftstack-ci-release-5.0-techpreview-e2e-openstack-ovn-serial-techpreview/2078882776429367296

Fixing this will allow to drop the [exception](https://github.com/openshift/origin/blob/main/pkg/monitortests/authentication/requiredsccmonitortests/monitortest.go#L62) from the required-scc-annotation-checker monitor test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Updated the operator deployment to require OpenShift’s `restricted-v2` security constraint for its pods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->